### PR TITLE
feat: 共通ユーティリティ関数の作成

### DIFF
--- a/src/lib/utils/__tests__/date.test.ts
+++ b/src/lib/utils/__tests__/date.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatDateJapanese,
+  formatDateSlash,
+  formatDateISO,
+  formatDateTime,
+  getFirstDayOfMonth,
+  getLastDayOfMonth,
+  isToday,
+  isFutureDate,
+  parseDate,
+  getToday,
+} from '../date';
+
+describe('date utilities', () => {
+  describe('formatDateJapanese', () => {
+    // UT-001-01: 正常な日付変換
+    it('should format date string to Japanese format', () => {
+      // 2025-01-15 is Wednesday
+      const result = formatDateJapanese('2025-01-15');
+      expect(result).toBe('2025年1月15日（水）');
+    });
+
+    it('should format Date object to Japanese format', () => {
+      const date = new Date(2025, 0, 15); // January 15, 2025
+      const result = formatDateJapanese(date);
+      expect(result).toBe('2025年1月15日（水）');
+    });
+
+    // UT-001-02: 無効な日付
+    it('should return null for invalid date string', () => {
+      const result = formatDateJapanese('invalid');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      const result = formatDateJapanese('');
+      expect(result).toBeNull();
+    });
+
+    // UT-001-03: null入力
+    it('should return null for null input', () => {
+      const result = formatDateJapanese(null);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for undefined input', () => {
+      const result = formatDateJapanese(undefined);
+      expect(result).toBeNull();
+    });
+
+    it('should correctly display all weekdays', () => {
+      const testCases = [
+        { date: '2025-01-12', expected: '2025年1月12日（日）' }, // Sunday
+        { date: '2025-01-13', expected: '2025年1月13日（月）' }, // Monday
+        { date: '2025-01-14', expected: '2025年1月14日（火）' }, // Tuesday
+        { date: '2025-01-15', expected: '2025年1月15日（水）' }, // Wednesday
+        { date: '2025-01-16', expected: '2025年1月16日（木）' }, // Thursday
+        { date: '2025-01-17', expected: '2025年1月17日（金）' }, // Friday
+        { date: '2025-01-18', expected: '2025年1月18日（土）' }, // Saturday
+      ];
+
+      testCases.forEach(({ date, expected }) => {
+        expect(formatDateJapanese(date)).toBe(expected);
+      });
+    });
+  });
+
+  describe('formatDateSlash', () => {
+    it('should format date to YYYY/MM/DD format', () => {
+      const result = formatDateSlash('2025-01-05');
+      expect(result).toBe('2025/01/05');
+    });
+
+    it('should pad single digit month and day with zeros', () => {
+      const result = formatDateSlash(new Date(2025, 0, 5)); // January 5
+      expect(result).toBe('2025/01/05');
+    });
+
+    it('should return null for invalid date', () => {
+      expect(formatDateSlash('invalid')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(formatDateSlash(null)).toBeNull();
+    });
+  });
+
+  describe('formatDateISO', () => {
+    it('should format date to YYYY-MM-DD format', () => {
+      const result = formatDateISO('2025-01-15');
+      expect(result).toBe('2025-01-15');
+    });
+
+    it('should format Date object to ISO format', () => {
+      const date = new Date(2025, 0, 5); // January 5, 2025
+      const result = formatDateISO(date);
+      expect(result).toBe('2025-01-05');
+    });
+
+    it('should return null for invalid date string', () => {
+      expect(formatDateISO('not-a-date')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(formatDateISO(null)).toBeNull();
+    });
+
+    it('should return null for undefined input', () => {
+      expect(formatDateISO(undefined)).toBeNull();
+    });
+  });
+
+  describe('formatDateTime', () => {
+    it('should format datetime to YYYY/MM/DD HH:MM format', () => {
+      const date = new Date(2025, 0, 15, 14, 30); // January 15, 2025, 14:30
+      const result = formatDateTime(date);
+      expect(result).toBe('2025/01/15 14:30');
+    });
+
+    it('should pad single digit hours and minutes', () => {
+      const date = new Date(2025, 0, 5, 9, 5); // January 5, 2025, 09:05
+      const result = formatDateTime(date);
+      expect(result).toBe('2025/01/05 09:05');
+    });
+
+    it('should return null for invalid date', () => {
+      expect(formatDateTime('invalid')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(formatDateTime(null)).toBeNull();
+    });
+  });
+
+  describe('getFirstDayOfMonth', () => {
+    it('should return first day of given month', () => {
+      const date = new Date(2025, 5, 15); // June 15, 2025
+      const result = getFirstDayOfMonth(date);
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(5); // June
+      expect(result.getDate()).toBe(1);
+    });
+
+    it('should return first day of current month when no argument', () => {
+      const result = getFirstDayOfMonth();
+      const now = new Date();
+      expect(result.getFullYear()).toBe(now.getFullYear());
+      expect(result.getMonth()).toBe(now.getMonth());
+      expect(result.getDate()).toBe(1);
+    });
+  });
+
+  describe('getLastDayOfMonth', () => {
+    it('should return last day of given month', () => {
+      const date = new Date(2025, 0, 15); // January 15, 2025
+      const result = getLastDayOfMonth(date);
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(0); // January
+      expect(result.getDate()).toBe(31);
+    });
+
+    it('should handle February in leap year', () => {
+      const date = new Date(2024, 1, 10); // February 10, 2024 (leap year)
+      const result = getLastDayOfMonth(date);
+      expect(result.getDate()).toBe(29);
+    });
+
+    it('should handle February in non-leap year', () => {
+      const date = new Date(2025, 1, 10); // February 10, 2025
+      const result = getLastDayOfMonth(date);
+      expect(result.getDate()).toBe(28);
+    });
+
+    it('should return last day of current month when no argument', () => {
+      const result = getLastDayOfMonth();
+      const now = new Date();
+      const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+      expect(result.getDate()).toBe(lastDay.getDate());
+    });
+  });
+
+  describe('isToday', () => {
+    it('should return true for today', () => {
+      const today = new Date();
+      expect(isToday(today)).toBe(true);
+    });
+
+    it('should return true for today as string', () => {
+      const today = new Date();
+      const todayString = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+      expect(isToday(todayString)).toBe(true);
+    });
+
+    it('should return false for yesterday', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      expect(isToday(yesterday)).toBe(false);
+    });
+
+    it('should return false for tomorrow', () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      expect(isToday(tomorrow)).toBe(false);
+    });
+  });
+
+  describe('isFutureDate', () => {
+    it('should return true for future date', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 1);
+      expect(isFutureDate(futureDate)).toBe(true);
+    });
+
+    it('should return true for future date as string', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 1);
+      const futureDateString = `${futureDate.getFullYear()}-${String(futureDate.getMonth() + 1).padStart(2, '0')}-${String(futureDate.getDate()).padStart(2, '0')}`;
+      expect(isFutureDate(futureDateString)).toBe(true);
+    });
+
+    it('should return false for today', () => {
+      const today = new Date();
+      expect(isFutureDate(today)).toBe(false);
+    });
+
+    it('should return false for past date', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 1);
+      expect(isFutureDate(pastDate)).toBe(false);
+    });
+
+    it('should not mutate the original Date object', () => {
+      const originalDate = new Date(2030, 0, 15, 10, 30, 45);
+      const originalTime = originalDate.getTime();
+      isFutureDate(originalDate);
+      expect(originalDate.getTime()).toBe(originalTime);
+    });
+  });
+
+  describe('parseDate', () => {
+    it('should parse valid date string to Date object', () => {
+      const result = parseDate('2025-01-15');
+      expect(result).toBeInstanceOf(Date);
+      expect(result?.getFullYear()).toBe(2025);
+      expect(result?.getMonth()).toBe(0); // January is 0
+      expect(result?.getDate()).toBe(15);
+    });
+
+    it('should parse various date formats', () => {
+      // ISO format
+      expect(parseDate('2025-06-20')).toBeInstanceOf(Date);
+
+      // Date with time
+      expect(parseDate('2025-01-15T10:30:00')).toBeInstanceOf(Date);
+    });
+
+    it('should return null for invalid date string', () => {
+      expect(parseDate('invalid')).toBeNull();
+      expect(parseDate('not-a-date')).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      expect(parseDate('')).toBeNull();
+    });
+
+    it('should return null for non-string input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(parseDate(null)).toBeNull();
+      // @ts-expect-error Testing invalid input
+      expect(parseDate(undefined)).toBeNull();
+      // @ts-expect-error Testing invalid input
+      expect(parseDate(12345)).toBeNull();
+    });
+  });
+
+  describe('getToday', () => {
+    it('should return today in YYYY-MM-DD format', () => {
+      const result = getToday();
+      const today = new Date();
+      const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+      expect(result).toBe(expected);
+    });
+
+    it('should match regex pattern YYYY-MM-DD', () => {
+      const result = getToday();
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('should pad single digit month and day with zeros', () => {
+      // We test the format consistency
+      const result = getToday();
+      const parts = result.split('-');
+      expect(parts[0]).toHaveLength(4); // Year
+      expect(parts[1]).toHaveLength(2); // Month
+      expect(parts[2]).toHaveLength(2); // Day
+    });
+
+    it('should return a parseable date string', () => {
+      const result = getToday();
+      const parsed = new Date(result);
+      expect(parsed).toBeInstanceOf(Date);
+      expect(isNaN(parsed.getTime())).toBe(false);
+    });
+  });
+});

--- a/src/lib/utils/__tests__/password.test.ts
+++ b/src/lib/utils/__tests__/password.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { hashPassword, verifyPassword } from '../password';
+
+describe('password utilities', () => {
+  describe('hashPassword', () => {
+    // UT-003-01: パスワードハッシュ化
+    it('should generate a hash for valid password', async () => {
+      const password = 'password123';
+      const hash = await hashPassword(password);
+
+      expect(hash).toBeDefined();
+      expect(typeof hash).toBe('string');
+      expect(hash.length).toBeGreaterThan(0);
+    });
+
+    it('should generate different hash for same password (due to salt)', async () => {
+      const password = 'password123';
+      const hash1 = await hashPassword(password);
+      const hash2 = await hashPassword(password);
+
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('should generate bcrypt format hash', async () => {
+      const password = 'testPassword';
+      const hash = await hashPassword(password);
+
+      // bcrypt hash starts with $2a$, $2b$, or $2y$
+      expect(hash).toMatch(/^\$2[aby]\$\d{1,2}\$.{53}$/);
+    });
+
+    it('should handle empty password', async () => {
+      const password = '';
+      const hash = await hashPassword(password);
+
+      expect(hash).toBeDefined();
+      expect(typeof hash).toBe('string');
+    });
+
+    it('should handle long password', async () => {
+      const password = 'a'.repeat(100);
+      const hash = await hashPassword(password);
+
+      expect(hash).toBeDefined();
+      expect(typeof hash).toBe('string');
+    });
+
+    it('should handle special characters in password', async () => {
+      const password = '!@#$%^&*()_+-=[]{}|;:,.<>?';
+      const hash = await hashPassword(password);
+
+      expect(hash).toBeDefined();
+      expect(typeof hash).toBe('string');
+    });
+
+    it('should handle unicode characters in password', async () => {
+      const password = 'パスワード123';
+      const hash = await hashPassword(password);
+
+      expect(hash).toBeDefined();
+      expect(typeof hash).toBe('string');
+    });
+  });
+
+  describe('verifyPassword', () => {
+    // UT-003-02: ハッシュ検証（正しい）
+    it('should return true for correct password', async () => {
+      const password = 'password123';
+      const hash = await hashPassword(password);
+      const result = await verifyPassword(password, hash);
+
+      expect(result).toBe(true);
+    });
+
+    // UT-003-03: ハッシュ検証（誤り）
+    it('should return false for incorrect password', async () => {
+      const password = 'password123';
+      const wrongPassword = 'wrongpassword';
+      const hash = await hashPassword(password);
+      const result = await verifyPassword(wrongPassword, hash);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for similar but different password', async () => {
+      const password = 'password123';
+      const similarPassword = 'password124';
+      const hash = await hashPassword(password);
+      const result = await verifyPassword(similarPassword, hash);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true for empty password when hashed correctly', async () => {
+      const password = '';
+      const hash = await hashPassword(password);
+      const result = await verifyPassword(password, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when verifying empty password against non-empty hash', async () => {
+      const password = 'password123';
+      const hash = await hashPassword(password);
+      const result = await verifyPassword('', hash);
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle special characters correctly', async () => {
+      const password = '!@#$%^&*()_+-=[]{}|;:,.<>?';
+      const hash = await hashPassword(password);
+      const result = await verifyPassword(password, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it('should handle unicode characters correctly', async () => {
+      const password = 'パスワード123';
+      const hash = await hashPassword(password);
+      const result = await verifyPassword(password, hash);
+
+      expect(result).toBe(true);
+    });
+
+    it('should be case sensitive', async () => {
+      const password = 'Password123';
+      const hash = await hashPassword(password);
+
+      expect(await verifyPassword('password123', hash)).toBe(false);
+      expect(await verifyPassword('PASSWORD123', hash)).toBe(false);
+      expect(await verifyPassword('Password123', hash)).toBe(true);
+    });
+
+    it('should handle whitespace correctly', async () => {
+      const password = 'password with spaces';
+      const hash = await hashPassword(password);
+
+      expect(await verifyPassword('password with spaces', hash)).toBe(true);
+      expect(await verifyPassword('passwordwithspaces', hash)).toBe(false);
+      expect(await verifyPassword(' password with spaces', hash)).toBe(false);
+    });
+  });
+});

--- a/src/lib/utils/__tests__/string.test.ts
+++ b/src/lib/utils/__tests__/string.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { truncate, escapeHtml } from '../string';
+
+describe('string utilities', () => {
+  describe('truncate', () => {
+    it('should return original string if shorter than maxLength', () => {
+      expect(truncate('Hello', 10)).toBe('Hello');
+    });
+
+    it('should return original string if equal to maxLength', () => {
+      expect(truncate('Hello', 5)).toBe('Hello');
+    });
+
+    it('should truncate and add ellipsis for longer strings', () => {
+      expect(truncate('Hello World', 8)).toBe('Hello...');
+    });
+
+    it('should handle maxLength less than or equal to 3', () => {
+      expect(truncate('Hello', 3)).toBe('Hel');
+      expect(truncate('Hello', 2)).toBe('He');
+      expect(truncate('Hello', 1)).toBe('H');
+    });
+
+    it('should return empty string for maxLength of 0', () => {
+      expect(truncate('Hello', 0)).toBe('');
+    });
+
+    it('should return empty string for negative maxLength', () => {
+      expect(truncate('Hello', -5)).toBe('');
+    });
+
+    it('should return empty string for empty input', () => {
+      expect(truncate('', 10)).toBe('');
+    });
+
+    it('should return empty string for null input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(truncate(null, 10)).toBe('');
+    });
+
+    it('should return empty string for undefined input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(truncate(undefined, 10)).toBe('');
+    });
+
+    it('should return empty string for non-string input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(truncate(12345, 10)).toBe('');
+    });
+
+    it('should handle Japanese characters correctly', () => {
+      const japanese = 'こんにちは世界';
+      expect(truncate(japanese, 5)).toBe('こん...');
+      expect(truncate(japanese, 7)).toBe(japanese);
+    });
+
+    it('should truncate strings with emoji (note: emoji may be split due to UTF-16)', () => {
+      // Note: JavaScript's slice operates on UTF-16 code units.
+      // Emojis are typically 2 code units, so they may be split during truncation.
+      // This is a known limitation of simple truncation.
+      const emoji = 'Hello 🌍🌎🌏';
+      const result = truncate(emoji, 10);
+      // The result will contain 7 characters from slice (10-3 for ellipsis)
+      // which may include partial emoji code units
+      expect(result.length).toBe(10);
+      expect(result.endsWith('...')).toBe(true);
+    });
+
+    it('should handle strings with newlines', () => {
+      const multiline = 'Line1\nLine2\nLine3';
+      expect(truncate(multiline, 10)).toBe('Line1\nL...');
+    });
+
+    it('should work with exact boundary cases', () => {
+      // String of exactly 4 characters, truncate to 4
+      expect(truncate('ABCD', 4)).toBe('ABCD');
+      // String of 5 characters, truncate to 4 (needs ellipsis but maxLength <= 3 behavior)
+      expect(truncate('ABCDE', 4)).toBe('A...');
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('should escape ampersand', () => {
+      expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+    });
+
+    it('should escape less than sign', () => {
+      expect(escapeHtml('a < b')).toBe('a &lt; b');
+    });
+
+    it('should escape greater than sign', () => {
+      expect(escapeHtml('a > b')).toBe('a &gt; b');
+    });
+
+    it('should escape double quotes', () => {
+      expect(escapeHtml('Say "Hello"')).toBe('Say &quot;Hello&quot;');
+    });
+
+    it('should escape single quotes', () => {
+      expect(escapeHtml("It's fine")).toBe('It&#x27;s fine');
+    });
+
+    it('should escape all special characters in HTML tags', () => {
+      expect(escapeHtml('<script>alert("XSS")</script>')).toBe(
+        '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;'
+      );
+    });
+
+    it('should escape multiple occurrences', () => {
+      expect(escapeHtml('a & b & c')).toBe('a &amp; b &amp; c');
+    });
+
+    it('should return original string if no special characters', () => {
+      expect(escapeHtml('Hello World')).toBe('Hello World');
+    });
+
+    it('should return empty string for empty input', () => {
+      expect(escapeHtml('')).toBe('');
+    });
+
+    it('should return empty string for null input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(escapeHtml(null)).toBe('');
+    });
+
+    it('should return empty string for undefined input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(escapeHtml(undefined)).toBe('');
+    });
+
+    it('should return empty string for non-string input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(escapeHtml(12345)).toBe('');
+    });
+
+    it('should handle mixed HTML content', () => {
+      const html = '<div class="test" data-value=\'123\'>&nbsp;</div>';
+      const expected =
+        '&lt;div class=&quot;test&quot; data-value=&#x27;123&#x27;&gt;&amp;nbsp;&lt;/div&gt;';
+      expect(escapeHtml(html)).toBe(expected);
+    });
+
+    it('should handle already escaped content (double escaping)', () => {
+      // Note: this function does not prevent double escaping
+      expect(escapeHtml('&amp;')).toBe('&amp;amp;');
+    });
+
+    it('should handle Japanese characters without escaping', () => {
+      expect(escapeHtml('こんにちは')).toBe('こんにちは');
+    });
+
+    it('should escape special characters in Japanese mixed content', () => {
+      expect(escapeHtml('価格: 1000円 & 税込')).toBe('価格: 1000円 &amp; 税込');
+    });
+
+    it('should handle newlines and whitespace', () => {
+      expect(escapeHtml('Hello\n<World>')).toBe('Hello\n&lt;World&gt;');
+    });
+  });
+});

--- a/src/lib/utils/__tests__/validation.test.ts
+++ b/src/lib/utils/__tests__/validation.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isValidEmail,
+  isValidPhone,
+  isValidEmployeeCode,
+  isValidCustomerCode,
+  isValidTimeFormat,
+} from '../validation';
+
+describe('validation utilities', () => {
+  describe('isValidEmail', () => {
+    // UT-002-01: 有効なメールアドレス
+    it('should return true for valid email', () => {
+      expect(isValidEmail('test@example.com')).toBe(true);
+    });
+
+    it('should return true for valid email with subdomain', () => {
+      expect(isValidEmail('user@mail.example.com')).toBe(true);
+    });
+
+    it('should return true for valid email with plus sign', () => {
+      expect(isValidEmail('user+tag@example.com')).toBe(true);
+    });
+
+    it('should return true for valid email with dots in local part', () => {
+      expect(isValidEmail('first.last@example.com')).toBe(true);
+    });
+
+    it('should return true for valid email with numbers', () => {
+      expect(isValidEmail('user123@example123.com')).toBe(true);
+    });
+
+    // UT-002-02: 無効なメールアドレス
+    it('should return false for email without @', () => {
+      expect(isValidEmail('invalid-email')).toBe(false);
+    });
+
+    it('should return false for email without domain', () => {
+      expect(isValidEmail('test@')).toBe(false);
+    });
+
+    it('should return false for email without local part', () => {
+      expect(isValidEmail('@example.com')).toBe(false);
+    });
+
+    it('should return false for email without TLD', () => {
+      expect(isValidEmail('test@example')).toBe(false);
+    });
+
+    it('should return false for email with spaces', () => {
+      expect(isValidEmail('test @example.com')).toBe(false);
+      expect(isValidEmail('test@ example.com')).toBe(false);
+    });
+
+    // UT-002-03: 空文字
+    it('should return false for empty string', () => {
+      expect(isValidEmail('')).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidEmail(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidEmail(undefined)).toBe(false);
+    });
+
+    it('should return false for non-string input', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidEmail(12345)).toBe(false);
+      // @ts-expect-error Testing invalid input
+      expect(isValidEmail({})).toBe(false);
+    });
+  });
+
+  describe('isValidPhone', () => {
+    // UT-002-04: 有効な電話番号
+    it('should return true for valid phone with hyphens', () => {
+      expect(isValidPhone('03-1234-5678')).toBe(true);
+    });
+
+    it('should return true for valid phone without hyphens', () => {
+      expect(isValidPhone('0312345678')).toBe(true);
+    });
+
+    it('should return true for mobile phone number', () => {
+      expect(isValidPhone('090-1234-5678')).toBe(true);
+      expect(isValidPhone('080-1234-5678')).toBe(true);
+      expect(isValidPhone('070-1234-5678')).toBe(true);
+    });
+
+    it('should return true for mobile phone without hyphens', () => {
+      expect(isValidPhone('09012345678')).toBe(true);
+    });
+
+    it('should return true for various area code formats', () => {
+      expect(isValidPhone('045-123-4567')).toBe(true);
+      expect(isValidPhone('0123-45-6789')).toBe(true);
+    });
+
+    // UT-002-05: 無効な電話番号
+    it('should return false for alphabetic characters', () => {
+      expect(isValidPhone('abcd')).toBe(false);
+    });
+
+    it('should return false for mixed alphanumeric', () => {
+      expect(isValidPhone('03-1234-abcd')).toBe(false);
+    });
+
+    it('should return false for phone not starting with 0', () => {
+      expect(isValidPhone('13-1234-5678')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isValidPhone('')).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidPhone(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidPhone(undefined)).toBe(false);
+    });
+
+    it('should return false for phone with spaces', () => {
+      expect(isValidPhone('03 1234 5678')).toBe(false);
+    });
+  });
+
+  describe('isValidEmployeeCode', () => {
+    it('should return true for alphanumeric code', () => {
+      expect(isValidEmployeeCode('EMP001')).toBe(true);
+    });
+
+    it('should return true for numeric only code', () => {
+      expect(isValidEmployeeCode('12345')).toBe(true);
+    });
+
+    it('should return true for alphabetic only code', () => {
+      expect(isValidEmployeeCode('ABCDEF')).toBe(true);
+    });
+
+    it('should return true for lowercase letters', () => {
+      expect(isValidEmployeeCode('emp001')).toBe(true);
+    });
+
+    it('should return true for single character', () => {
+      expect(isValidEmployeeCode('A')).toBe(true);
+    });
+
+    it('should return true for 20 character code (max length)', () => {
+      expect(isValidEmployeeCode('A'.repeat(20))).toBe(true);
+    });
+
+    it('should return false for 21 character code (exceeds max)', () => {
+      expect(isValidEmployeeCode('A'.repeat(21))).toBe(false);
+    });
+
+    it('should return false for code with hyphens', () => {
+      expect(isValidEmployeeCode('EMP-001')).toBe(false);
+    });
+
+    it('should return false for code with underscores', () => {
+      expect(isValidEmployeeCode('EMP_001')).toBe(false);
+    });
+
+    it('should return false for code with spaces', () => {
+      expect(isValidEmployeeCode('EMP 001')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isValidEmployeeCode('')).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidEmployeeCode(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidEmployeeCode(undefined)).toBe(false);
+    });
+
+    it('should return false for Japanese characters', () => {
+      expect(isValidEmployeeCode('従業員001')).toBe(false);
+    });
+  });
+
+  describe('isValidCustomerCode', () => {
+    it('should return true for alphanumeric code', () => {
+      expect(isValidCustomerCode('C001')).toBe(true);
+    });
+
+    it('should return true for numeric only code', () => {
+      expect(isValidCustomerCode('12345')).toBe(true);
+    });
+
+    it('should return true for alphabetic only code', () => {
+      expect(isValidCustomerCode('CUSTOMER')).toBe(true);
+    });
+
+    it('should return true for lowercase letters', () => {
+      expect(isValidCustomerCode('customer001')).toBe(true);
+    });
+
+    it('should return true for single character', () => {
+      expect(isValidCustomerCode('C')).toBe(true);
+    });
+
+    it('should return true for 20 character code (max length)', () => {
+      expect(isValidCustomerCode('C'.repeat(20))).toBe(true);
+    });
+
+    it('should return false for 21 character code (exceeds max)', () => {
+      expect(isValidCustomerCode('C'.repeat(21))).toBe(false);
+    });
+
+    it('should return false for code with hyphens', () => {
+      expect(isValidCustomerCode('CUST-001')).toBe(false);
+    });
+
+    it('should return false for code with special characters', () => {
+      expect(isValidCustomerCode('C@001')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isValidCustomerCode('')).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidCustomerCode(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidCustomerCode(undefined)).toBe(false);
+    });
+  });
+
+  describe('isValidTimeFormat', () => {
+    it('should return true for valid time format', () => {
+      expect(isValidTimeFormat('10:00')).toBe(true);
+      expect(isValidTimeFormat('09:30')).toBe(true);
+      expect(isValidTimeFormat('23:59')).toBe(true);
+      expect(isValidTimeFormat('00:00')).toBe(true);
+    });
+
+    it('should return false for invalid hour', () => {
+      expect(isValidTimeFormat('24:00')).toBe(false);
+      expect(isValidTimeFormat('25:00')).toBe(false);
+    });
+
+    it('should return false for invalid minute', () => {
+      expect(isValidTimeFormat('10:60')).toBe(false);
+      expect(isValidTimeFormat('10:99')).toBe(false);
+    });
+
+    it('should return false for missing leading zero', () => {
+      expect(isValidTimeFormat('9:30')).toBe(false);
+      expect(isValidTimeFormat('10:5')).toBe(false);
+    });
+
+    it('should return false for invalid format', () => {
+      expect(isValidTimeFormat('10-00')).toBe(false);
+      expect(isValidTimeFormat('10:00:00')).toBe(false);
+      expect(isValidTimeFormat('1000')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isValidTimeFormat('')).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidTimeFormat(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      // @ts-expect-error Testing invalid input
+      expect(isValidTimeFormat(undefined)).toBe(false);
+    });
+  });
+});

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -129,3 +129,31 @@ export function isFutureDate(date: Date | string): boolean {
 
   return d > today;
 }
+
+/**
+ * 文字列からDateオブジェクトに変換
+ * @param dateString 日付文字列（YYYY-MM-DD形式を想定）
+ * @returns Dateオブジェクト、無効な場合はnull
+ */
+export function parseDate(dateString: string): Date | null {
+  if (!dateString || typeof dateString !== 'string') return null;
+
+  const d = new Date(dateString);
+
+  if (isNaN(d.getTime())) return null;
+
+  return d;
+}
+
+/**
+ * 今日の日付を取得（YYYY-MM-DD形式）
+ * @returns 今日の日付文字列
+ */
+export function getToday(): string {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './date';
 export * from './validation';
+export * from './string';
 // password は サーバーサイドのみで使用するため、明示的にインポートする必要がある
 // export * from "./password";

--- a/src/lib/utils/string.ts
+++ b/src/lib/utils/string.ts
@@ -1,0 +1,41 @@
+/**
+ * 文字列ユーティリティ関数
+ */
+
+/**
+ * 文字列を指定文字数で切り詰め
+ * @param str 対象文字列
+ * @param maxLength 最大文字数
+ * @returns 切り詰められた文字列（省略時は末尾に...を付加）
+ */
+export function truncate(str: string, maxLength: number): string {
+  if (!str || typeof str !== 'string') return '';
+  if (maxLength < 0) return '';
+  if (maxLength === 0) return '';
+
+  if (str.length <= maxLength) return str;
+
+  // 省略記号 "..." を含めて maxLength 以内に収める
+  if (maxLength <= 3) return str.slice(0, maxLength);
+
+  return str.slice(0, maxLength - 3) + '...';
+}
+
+/**
+ * HTMLエスケープ
+ * @param str エスケープする文字列
+ * @returns HTMLエスケープされた文字列
+ */
+export function escapeHtml(str: string): string {
+  if (!str || typeof str !== 'string') return '';
+
+  const escapeMap: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+  };
+
+  return str.replace(/[&<>"']/g, (char) => escapeMap[char]);
+}


### PR DESCRIPTION
## Summary
- 日付ユーティリティ関数（parseDate, getToday）を追加
- 文字列ユーティリティ関数（truncate, escapeHtml）を新規作成
- 全ユーティリティ関数の単体テスト（151テストケース）を作成

## 変更内容

### 追加した関数
| ファイル | 関数 | 説明 |
|---------|------|------|
| date.ts | parseDate | 文字列からDateオブジェクトへの変換 |
| date.ts | getToday | 今日の日付をYYYY-MM-DD形式で取得 |
| string.ts | truncate | 文字列を指定文字数で切り詰め |
| string.ts | escapeHtml | HTMLエスケープ（XSS対策） |

### テストファイル
| ファイル | テスト数 | 対象 |
|---------|---------|------|
| date.test.ts | 44 | formatDateJapanese, parseDate, getToday等 |
| password.test.ts | 16 | hashPassword, verifyPassword |
| validation.test.ts | 60 | isValidEmail, isValidPhone等 |
| string.test.ts | 31 | truncate, escapeHtml |

## 対応Issue
Closes #5

## Test plan
- [x] `npm run test` で全167テストがパス
- [x] ESLintエラーなし
- [x] TypeScript型チェックOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)