### PR TITLE
feat: 認証ミドルウェアの実装 (#10)

### DIFF
--- a/src/lib/auth/__tests__/middleware.test.ts
+++ b/src/lib/auth/__tests__/middleware.test.ts
@@ -1,0 +1,547 @@
+/**
+ * 認証ミドルウェアのテスト
+ *
+ * @vitest-environment node
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+
+import { prisma } from '@/lib/prisma';
+import type { UserRole, JwtPayload, ApiErrorResponse } from '@/types';
+
+import { generateToken } from '../jwt';
+import {
+  withAuth,
+  withRole,
+  withAdmin,
+  isSubordinate,
+  canViewReport,
+  canPostComment,
+  canEditReport,
+  canManageMaster,
+  AuthUser,
+} from '../middleware';
+
+// Prismaのモック
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    salesPerson: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+const TEST_SECRET = 'test-secret-key-for-testing-only-32-chars';
+
+/**
+ * テスト用のNextRequestを作成するヘルパー
+ */
+function createMockRequest(options: {
+  authHeader?: string | null;
+  method?: string;
+  url?: string;
+}): NextRequest {
+  const url = options.url || 'http://localhost:3000/api/test';
+  const request = new NextRequest(url, {
+    method: options.method || 'GET',
+  });
+
+  if (options.authHeader !== null && options.authHeader !== undefined) {
+    // headersは読み取り専用なのでモック用に新しいリクエストを作成
+    const headers = new Headers();
+    headers.set('Authorization', options.authHeader);
+
+    return new NextRequest(url, {
+      method: options.method || 'GET',
+      headers,
+    });
+  }
+
+  return request;
+}
+
+describe('認証ミドルウェア', () => {
+  const testPayload: JwtPayload = {
+    userId: 1,
+    email: 'test@example.com',
+    role: 'member',
+  };
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+  });
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('withAuth', () => {
+    it('有効なトークンで認証成功し、ハンドラーが実行される', async () => {
+      const token = await generateToken(testPayload);
+      const request = createMockRequest({ authHeader: `Bearer ${token}` });
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(
+          NextResponse.json({ success: true, data: { userId: testPayload.userId } })
+        );
+
+      const response = await withAuth(request, handler);
+      const body = await response.json();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({
+          id: testPayload.userId,
+          email: testPayload.email,
+          role: testPayload.role,
+        })
+      );
+      expect(body.success).toBe(true);
+      expect(body.data.userId).toBe(testPayload.userId);
+    });
+
+    it('Authorizationヘッダーがない場合は401エラーを返す', async () => {
+      const request = createMockRequest({});
+      const handler = vi.fn();
+
+      const response = await withAuth(request, handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('無効なトークンの場合は401エラーを返す', async () => {
+      const request = createMockRequest({ authHeader: 'Bearer invalid-token' });
+      const handler = vi.fn();
+
+      const response = await withAuth(request, handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('Bearer形式でないトークンの場合は401エラーを返す', async () => {
+      const token = await generateToken(testPayload);
+      const request = createMockRequest({ authHeader: `Basic ${token}` });
+      const handler = vi.fn();
+
+      const response = await withAuth(request, handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('期限切れのトークンの場合は401エラーを返す', async () => {
+      // 期限切れトークンをシミュレート（改竄されたトークン）
+      const token = await generateToken(testPayload);
+      const tamperedToken = token.slice(0, -5) + 'xxxxx';
+      const request = createMockRequest({ authHeader: `Bearer ${tamperedToken}` });
+      const handler = vi.fn();
+
+      const response = await withAuth(request, handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('全てのロールで認証できる', async () => {
+      const roles: UserRole[] = ['member', 'manager', 'admin'];
+
+      for (const role of roles) {
+        const payload: JwtPayload = { ...testPayload, role };
+        const token = await generateToken(payload);
+        const request = createMockRequest({ authHeader: `Bearer ${token}` });
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ success: true, data: {} }));
+
+        const response = await withAuth(request, handler);
+        const body = await response.json();
+
+        expect(handler).toHaveBeenCalledWith(request, expect.objectContaining({ role }));
+        expect(body.success).toBe(true);
+      }
+    });
+  });
+
+  describe('withRole', () => {
+    it('許可されたロールの場合、ハンドラーが実行される', async () => {
+      const payload: JwtPayload = { ...testPayload, role: 'manager' };
+      const token = await generateToken(payload);
+      const request = createMockRequest({ authHeader: `Bearer ${token}` });
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ success: true, data: { message: 'success' } }));
+
+      const response = await withRole(request, ['manager', 'admin'], handler);
+      const body = await response.json();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(body.success).toBe(true);
+    });
+
+    it('許可されていないロールの場合は403エラーを返す', async () => {
+      const payload: JwtPayload = { ...testPayload, role: 'member' };
+      const token = await generateToken(payload);
+      const request = createMockRequest({ authHeader: `Bearer ${token}` });
+
+      const handler = vi.fn();
+
+      const response = await withRole(request, ['manager', 'admin'], handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('FORBIDDEN');
+    });
+
+    it('認証されていない場合は401エラーを返す', async () => {
+      const request = createMockRequest({});
+      const handler = vi.fn();
+
+      const response = await withRole(request, ['admin'], handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('adminは許可リストに含まれていれば通過できる', async () => {
+      const payload: JwtPayload = { ...testPayload, role: 'admin' };
+      const token = await generateToken(payload);
+      const request = createMockRequest({ authHeader: `Bearer ${token}` });
+
+      const handler = vi.fn().mockResolvedValue(NextResponse.json({ success: true, data: {} }));
+
+      const response = await withRole(request, ['admin'], handler);
+      const body = await response.json();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(body.success).toBe(true);
+    });
+
+    it('複数のロールが許可されている場合、いずれかのロールで通過できる', async () => {
+      const allowedRoles: UserRole[] = ['member', 'manager', 'admin'];
+
+      for (const role of allowedRoles) {
+        const payload: JwtPayload = { ...testPayload, role };
+        const token = await generateToken(payload);
+        const request = createMockRequest({ authHeader: `Bearer ${token}` });
+        const handler = vi.fn().mockResolvedValue(NextResponse.json({ success: true, data: {} }));
+
+        const response = await withRole(request, allowedRoles, handler);
+        const body = await response.json();
+
+        expect(handler).toHaveBeenCalled();
+        expect(body.success).toBe(true);
+      }
+    });
+  });
+
+  describe('withAdmin', () => {
+    it('adminロールの場合、ハンドラーが実行される', async () => {
+      const payload: JwtPayload = { ...testPayload, role: 'admin' };
+      const token = await generateToken(payload);
+      const request = createMockRequest({ authHeader: `Bearer ${token}` });
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ success: true, data: { message: 'admin only' } }));
+
+      const response = await withAdmin(request, handler);
+      const body = await response.json();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(body.success).toBe(true);
+    });
+
+    it('memberロールの場合は403エラーを返す', async () => {
+      const payload: JwtPayload = { ...testPayload, role: 'member' };
+      const token = await generateToken(payload);
+      const request = createMockRequest({ authHeader: `Bearer ${token}` });
+
+      const handler = vi.fn();
+
+      const response = await withAdmin(request, handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('FORBIDDEN');
+    });
+
+    it('managerロールの場合は403エラーを返す', async () => {
+      const payload: JwtPayload = { ...testPayload, role: 'manager' };
+      const token = await generateToken(payload);
+      const request = createMockRequest({ authHeader: `Bearer ${token}` });
+
+      const handler = vi.fn();
+
+      const response = await withAdmin(request, handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('FORBIDDEN');
+    });
+
+    it('認証されていない場合は401エラーを返す', async () => {
+      const request = createMockRequest({});
+      const handler = vi.fn();
+
+      const response = await withAdmin(request, handler);
+      const body = (await response.json()) as ApiErrorResponse;
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+  });
+
+  describe('isSubordinate', () => {
+    it('対象ユーザーがマネージャーの部下の場合trueを返す', async () => {
+      const managerId = 3;
+      const subordinateId = 1;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue({
+        managerId: managerId,
+      } as never);
+
+      const result = await isSubordinate(managerId, subordinateId);
+
+      expect(result).toBe(true);
+      expect(prisma.salesPerson.findUnique).toHaveBeenCalledWith({
+        where: { id: subordinateId },
+        select: { managerId: true },
+      });
+    });
+
+    it('対象ユーザーがマネージャーの部下でない場合falseを返す', async () => {
+      const managerId = 3;
+      const otherUserId = 5;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue({
+        managerId: 99, // 別のマネージャー
+      } as never);
+
+      const result = await isSubordinate(managerId, otherUserId);
+
+      expect(result).toBe(false);
+    });
+
+    it('対象ユーザーが存在しない場合falseを返す', async () => {
+      const managerId = 3;
+      const nonExistentUserId = 999;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue(null);
+
+      const result = await isSubordinate(managerId, nonExistentUserId);
+
+      expect(result).toBe(false);
+    });
+
+    it('同じユーザーIDの場合falseを返す（自分は自分の部下ではない）', async () => {
+      const userId = 1;
+
+      const result = await isSubordinate(userId, userId);
+
+      expect(result).toBe(false);
+      expect(prisma.salesPerson.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('対象ユーザーにマネージャーが設定されていない場合falseを返す', async () => {
+      const managerId = 3;
+      const userWithoutManagerId = 5;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue({
+        managerId: null,
+      } as never);
+
+      const result = await isSubordinate(managerId, userWithoutManagerId);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('canViewReport', () => {
+    const memberUser: AuthUser = { id: 1, email: 'member@example.com', role: 'member' };
+    const managerUser: AuthUser = { id: 3, email: 'manager@example.com', role: 'manager' };
+    const adminUser: AuthUser = { id: 4, email: 'admin@example.com', role: 'admin' };
+
+    it('adminは全ての日報を閲覧可能', async () => {
+      const reportOwnerId = 99;
+
+      const result = await canViewReport(adminUser, reportOwnerId);
+
+      expect(result).toBe(true);
+      expect(prisma.salesPerson.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('自分の日報は誰でも閲覧可能', async () => {
+      const result = await canViewReport(memberUser, memberUser.id);
+
+      expect(result).toBe(true);
+      expect(prisma.salesPerson.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('managerは部下の日報を閲覧可能', async () => {
+      const subordinateId = 1;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue({
+        managerId: managerUser.id,
+      } as never);
+
+      const result = await canViewReport(managerUser, subordinateId);
+
+      expect(result).toBe(true);
+    });
+
+    it('managerは部下以外の日報を閲覧不可', async () => {
+      const otherUserId = 99;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue({
+        managerId: 999, // 別のマネージャー
+      } as never);
+
+      const result = await canViewReport(managerUser, otherUserId);
+
+      expect(result).toBe(false);
+    });
+
+    it('memberは他人の日報を閲覧不可', async () => {
+      const otherUserId = 2;
+
+      const result = await canViewReport(memberUser, otherUserId);
+
+      expect(result).toBe(false);
+      expect(prisma.salesPerson.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('canPostComment', () => {
+    const memberUser: AuthUser = { id: 1, email: 'member@example.com', role: 'member' };
+    const managerUser: AuthUser = { id: 3, email: 'manager@example.com', role: 'manager' };
+    const adminUser: AuthUser = { id: 4, email: 'admin@example.com', role: 'admin' };
+
+    it('adminは全ての日報にコメント可能', async () => {
+      const reportOwnerId = 99;
+
+      const result = await canPostComment(adminUser, reportOwnerId);
+
+      expect(result).toBe(true);
+    });
+
+    it('managerは部下の日報にコメント可能', async () => {
+      const subordinateId = 1;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue({
+        managerId: managerUser.id,
+      } as never);
+
+      const result = await canPostComment(managerUser, subordinateId);
+
+      expect(result).toBe(true);
+    });
+
+    it('managerは部下以外の日報にコメント不可', async () => {
+      const otherUserId = 99;
+
+      vi.mocked(prisma.salesPerson.findUnique).mockResolvedValue({
+        managerId: 999,
+      } as never);
+
+      const result = await canPostComment(managerUser, otherUserId);
+
+      expect(result).toBe(false);
+    });
+
+    it('memberはコメント不可', async () => {
+      const anyUserId = 2;
+
+      const result = await canPostComment(memberUser, anyUserId);
+
+      expect(result).toBe(false);
+    });
+
+    it('memberは自分の日報にもコメント不可', async () => {
+      const result = await canPostComment(memberUser, memberUser.id);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('canEditReport', () => {
+    const user: AuthUser = { id: 1, email: 'test@example.com', role: 'member' };
+
+    it('自分の日報は編集可能', () => {
+      const result = canEditReport(user, user.id);
+
+      expect(result).toBe(true);
+    });
+
+    it('他人の日報は編集不可', () => {
+      const result = canEditReport(user, 99);
+
+      expect(result).toBe(false);
+    });
+
+    it('adminでも他人の日報は編集不可', () => {
+      const adminUser: AuthUser = { id: 4, email: 'admin@example.com', role: 'admin' };
+
+      const result = canEditReport(adminUser, 1);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('canManageMaster', () => {
+    it('adminはマスタ管理可能', () => {
+      const adminUser: AuthUser = { id: 4, email: 'admin@example.com', role: 'admin' };
+
+      const result = canManageMaster(adminUser);
+
+      expect(result).toBe(true);
+    });
+
+    it('managerはマスタ管理不可', () => {
+      const managerUser: AuthUser = { id: 3, email: 'manager@example.com', role: 'manager' };
+
+      const result = canManageMaster(managerUser);
+
+      expect(result).toBe(false);
+    });
+
+    it('memberはマスタ管理不可', () => {
+      const memberUser: AuthUser = { id: 1, email: 'member@example.com', role: 'member' };
+
+      const result = canManageMaster(memberUser);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,7 +1,7 @@
 /**
  * 認証モジュール
  *
- * JWT認証とCookie操作に関するユーティリティをエクスポートする。
+ * JWT認証、Cookie操作、認証ミドルウェアに関するユーティリティをエクスポートする。
  */
 
 // JWT関連
@@ -22,3 +22,18 @@ export {
   hasAuthCookie,
   AUTH_COOKIE_CONFIG,
 } from './cookie';
+
+// ミドルウェア関連
+export {
+  withAuth,
+  withRole,
+  withAdmin,
+  isSubordinate,
+  canViewReport,
+  canPostComment,
+  canEditReport,
+  canManageMaster,
+} from './middleware';
+
+// ミドルウェアの型定義
+export type { AuthUser, AuthenticatedHandler } from './middleware';

--- a/src/lib/auth/middleware.ts
+++ b/src/lib/auth/middleware.ts
@@ -1,0 +1,299 @@
+/**
+ * 認証ミドルウェア
+ *
+ * Next.js API RouteでJWT認証とロールベースアクセス制御を提供する。
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { errorResponse } from '@/lib/api/response';
+import { prisma } from '@/lib/prisma';
+import type { UserRole } from '@/types';
+
+import { verifyToken, extractTokenFromHeader } from './jwt';
+
+/**
+ * 認証済みユーザー情報
+ */
+export interface AuthUser {
+  id: number;
+  email: string;
+  role: UserRole;
+}
+
+/**
+ * 認証ハンドラーの型
+ */
+export type AuthenticatedHandler<T = unknown> = (
+  request: NextRequest,
+  user: AuthUser
+) => Promise<NextResponse<T>>;
+
+/**
+ * 認証チェックを行うミドルウェア
+ *
+ * AuthorizationヘッダーからJWTトークンを検証し、
+ * 有効なトークンであればユーザー情報を含めてハンドラーを実行する。
+ *
+ * @param request - Next.jsリクエストオブジェクト
+ * @param handler - 認証成功時に実行するハンドラー
+ * @returns ハンドラーの戻り値またはエラーレスポンス
+ *
+ * @example
+ * ```typescript
+ * export async function GET(request: NextRequest) {
+ *   return withAuth(request, async (req, user) => {
+ *     // user.id, user.email, user.role が利用可能
+ *     return successResponse({ userId: user.id });
+ *   });
+ * }
+ * ```
+ */
+export async function withAuth<T>(
+  request: NextRequest,
+  handler: AuthenticatedHandler<T>
+): Promise<NextResponse<T> | NextResponse> {
+  // Authorizationヘッダーからトークンを抽出
+  const authHeader = request.headers.get('Authorization');
+  const token = extractTokenFromHeader(authHeader);
+
+  if (!token) {
+    return errorResponse('UNAUTHORIZED', '認証が必要です');
+  }
+
+  // トークンを検証
+  const result = await verifyToken(token);
+
+  if (!result.valid || !result.payload) {
+    return errorResponse('UNAUTHORIZED', result.error || '認証に失敗しました');
+  }
+
+  // ユーザー情報を構築
+  const user: AuthUser = {
+    id: result.payload.userId,
+    email: result.payload.email,
+    role: result.payload.role,
+  };
+
+  // ハンドラーを実行
+  return handler(request, user);
+}
+
+/**
+ * 特定ロールのみアクセス可能にするミドルウェア
+ *
+ * 認証チェックに加えて、指定されたロールのいずれかを持つユーザーのみ
+ * ハンドラーを実行する。
+ *
+ * @param request - Next.jsリクエストオブジェクト
+ * @param allowedRoles - 許可するロールの配列
+ * @param handler - 認証・認可成功時に実行するハンドラー
+ * @returns ハンドラーの戻り値またはエラーレスポンス
+ *
+ * @example
+ * ```typescript
+ * export async function POST(request: NextRequest) {
+ *   return withRole(request, ['manager', 'admin'], async (req, user) => {
+ *     // manager または admin のみ実行可能
+ *     return successResponse({ success: true });
+ *   });
+ * }
+ * ```
+ */
+export async function withRole<T>(
+  request: NextRequest,
+  allowedRoles: UserRole[],
+  handler: AuthenticatedHandler<T>
+): Promise<NextResponse<T> | NextResponse> {
+  // Authorizationヘッダーからトークンを抽出
+  const authHeader = request.headers.get('Authorization');
+  const token = extractTokenFromHeader(authHeader);
+
+  if (!token) {
+    return errorResponse('UNAUTHORIZED', '認証が必要です');
+  }
+
+  // トークンを検証
+  const result = await verifyToken(token);
+
+  if (!result.valid || !result.payload) {
+    return errorResponse('UNAUTHORIZED', result.error || '認証に失敗しました');
+  }
+
+  // ユーザー情報を構築
+  const user: AuthUser = {
+    id: result.payload.userId,
+    email: result.payload.email,
+    role: result.payload.role,
+  };
+
+  // ロールチェック
+  if (!allowedRoles.includes(user.role)) {
+    return errorResponse('FORBIDDEN', 'この操作を行う権限がありません');
+  }
+
+  // ハンドラーを実行
+  return handler(request, user);
+}
+
+/**
+ * 管理者のみアクセス可能にするミドルウェア
+ *
+ * withRoleのショートカットで、adminロールのみアクセスを許可する。
+ *
+ * @param request - Next.jsリクエストオブジェクト
+ * @param handler - 認証・認可成功時に実行するハンドラー
+ * @returns ハンドラーの戻り値またはエラーレスポンス
+ *
+ * @example
+ * ```typescript
+ * export async function DELETE(request: NextRequest) {
+ *   return withAdmin(request, async (req, user) => {
+ *     // admin のみ実行可能
+ *     return successResponse({ message: '削除しました' });
+ *   });
+ * }
+ * ```
+ */
+export async function withAdmin<T>(
+  request: NextRequest,
+  handler: AuthenticatedHandler<T>
+): Promise<NextResponse<T> | NextResponse> {
+  return withRole(request, ['admin'], handler);
+}
+
+/**
+ * 対象ユーザーが指定マネージャーの部下かどうかを判定
+ *
+ * データベースを参照し、targetUserIdのmanager_idがmanagerIdと一致するか確認する。
+ *
+ * @param managerId - マネージャーのユーザーID
+ * @param targetUserId - 対象ユーザーのID
+ * @returns 部下であればtrue、そうでなければfalse
+ *
+ * @example
+ * ```typescript
+ * const canAccess = await isSubordinate(currentUser.id, report.salesPersonId);
+ * if (!canAccess) {
+ *   return errorResponse('FORBIDDEN', 'アクセス権限がありません');
+ * }
+ * ```
+ */
+export async function isSubordinate(managerId: number, targetUserId: number): Promise<boolean> {
+  // 同じユーザーの場合はfalse（自分は自分の部下ではない）
+  if (managerId === targetUserId) {
+    return false;
+  }
+
+  const targetUser = await prisma.salesPerson.findUnique({
+    where: { id: targetUserId },
+    select: { managerId: true },
+  });
+
+  if (!targetUser) {
+    return false;
+  }
+
+  return targetUser.managerId === managerId;
+}
+
+/**
+ * ユーザーが日報を閲覧できるかを判定
+ *
+ * 権限マトリックスに基づいて閲覧権限を判定する:
+ * - member: 自分の日報のみ
+ * - manager: 自分の日報 + 部下の日報
+ * - admin: すべての日報
+ *
+ * @param user - 認証済みユーザー情報
+ * @param reportOwnerId - 日報作成者のユーザーID
+ * @returns 閲覧可能であればtrue、そうでなければfalse
+ *
+ * @example
+ * ```typescript
+ * const report = await prisma.dailyReport.findUnique({ ... });
+ * const canView = await canViewReport(user, report.salesPersonId);
+ * if (!canView) {
+ *   return errorResponse('FORBIDDEN', 'この日報を閲覧する権限がありません');
+ * }
+ * ```
+ */
+export async function canViewReport(user: AuthUser, reportOwnerId: number): Promise<boolean> {
+  // adminは全ての日報を閲覧可能
+  if (user.role === 'admin') {
+    return true;
+  }
+
+  // 自分の日報は閲覧可能
+  if (user.id === reportOwnerId) {
+    return true;
+  }
+
+  // managerは部下の日報を閲覧可能
+  if (user.role === 'manager') {
+    return isSubordinate(user.id, reportOwnerId);
+  }
+
+  // memberは自分の日報のみ（上記で処理済み）
+  return false;
+}
+
+/**
+ * ユーザーがコメントを投稿できるかを判定
+ *
+ * 権限マトリックスに基づいてコメント権限を判定する:
+ * - member: コメント不可
+ * - manager: 部下の日報にコメント可能
+ * - admin: すべての日報にコメント可能
+ *
+ * @param user - 認証済みユーザー情報
+ * @param reportOwnerId - 日報作成者のユーザーID
+ * @returns コメント可能であればtrue、そうでなければfalse
+ *
+ * @example
+ * ```typescript
+ * const canComment = await canPostComment(user, report.salesPersonId);
+ * if (!canComment) {
+ *   return errorResponse('FORBIDDEN', 'コメント投稿権限がありません');
+ * }
+ * ```
+ */
+export async function canPostComment(user: AuthUser, reportOwnerId: number): Promise<boolean> {
+  // adminはすべての日報にコメント可能
+  if (user.role === 'admin') {
+    return true;
+  }
+
+  // managerは部下の日報にコメント可能
+  if (user.role === 'manager') {
+    return isSubordinate(user.id, reportOwnerId);
+  }
+
+  // memberはコメント不可
+  return false;
+}
+
+/**
+ * ユーザーが日報を編集/削除できるかを判定
+ *
+ * 本人のみ編集/削除可能
+ *
+ * @param user - 認証済みユーザー情報
+ * @param reportOwnerId - 日報作成者のユーザーID
+ * @returns 編集可能であればtrue、そうでなければfalse
+ */
+export function canEditReport(user: AuthUser, reportOwnerId: number): boolean {
+  return user.id === reportOwnerId;
+}
+
+/**
+ * ユーザーがマスタ管理操作を行えるかを判定
+ *
+ * 管理者のみマスタ管理可能
+ *
+ * @param user - 認証済みユーザー情報
+ * @returns マスタ管理可能であればtrue、そうでなければfalse
+ */
+export function canManageMaster(user: AuthUser): boolean {
+  return user.role === 'admin';
+}


### PR DESCRIPTION
## Summary

- 認証・認可のためのミドルウェアとヘルパー関数を実装
- `withAuth`, `withRole`, `withAdmin` のミドルウェア関数でAPIエンドポイントを保護
- `isSubordinate`, `canViewReport`, `canPostComment`, `canEditReport`, `canManageMaster` のヘルパー関数で権限チェックを実装
- 36件のテストで全機能をカバー

## Implementation Details

### Middleware Functions

| 関数名 | 説明 |
|--------|------|
| `withAuth` | JWT認証チェック。有効なトークンがない場合は401を返す |
| `withRole` | 特定ロールのみアクセス許可。許可されていないロールは403を返す |
| `withAdmin` | 管理者のみアクセス許可。`withRole(['admin'])` のショートカット |

### Helper Functions

| 関数名 | 説明 |
|--------|------|
| `isSubordinate` | 対象ユーザーがマネージャーの部下かどうかを判定 |
| `canViewReport` | 日報閲覧権限をチェック |
| `canPostComment` | コメント投稿権限をチェック |
| `canEditReport` | 日報編集権限をチェック（本人のみ） |
| `canManageMaster` | マスタ管理権限をチェック（adminのみ） |

### Permission Matrix

| 権限 | 日報作成 | 日報閲覧 | コメント投稿 | マスタ管理 |
|------|----------|----------|--------------|------------|
| member | 自分のみ | 自分のみ | x | x |
| manager | 自分のみ | 部下含む | o | x |
| admin | o | 全員分 | o | o |

## Test plan

- [x] `withAuth`: 有効トークンで認証成功、トークンなしで401、無効トークンで401
- [x] `withRole`: 許可ロールで成功、非許可ロールで403
- [x] `withAdmin`: adminで成功、非adminで403
- [x] `isSubordinate`: 部下判定テスト
- [x] `canViewReport`: 各ロールでの閲覧権限テスト
- [x] `canPostComment`: 各ロールでのコメント投稿権限テスト
- [x] `canEditReport`: 本人のみ編集可能テスト
- [x] `canManageMaster`: adminのみマスタ管理可能テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)