### PR TITLE
feat: POST /api/v1/auth/logout の実装 (#12)

### DIFF
--- a/src/app/api/v1/auth/logout/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/logout/__tests__/route.test.ts
@@ -1,0 +1,327 @@
+/**
+ * POST /api/v1/auth/logout のテスト
+ *
+ * テスト仕様書 IT-002 に基づいた結合テスト
+ */
+
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { POST } from '../route';
+
+// JWT検証のモック
+const mockVerifyToken = vi.fn();
+const mockExtractTokenFromHeader = vi.fn();
+vi.mock('@/lib/auth/jwt', () => ({
+  verifyToken: (...args: unknown[]) => mockVerifyToken(...args),
+  extractTokenFromHeader: (header: string | null) => mockExtractTokenFromHeader(header),
+}));
+
+// Cookie操作のモック
+const mockClearAuthCookie = vi.fn();
+vi.mock('@/lib/auth/cookie', () => ({
+  clearAuthCookie: () => mockClearAuthCookie(),
+}));
+
+// Prismaのモック（middleware内で使用される可能性があるため）
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    salesPerson: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+/**
+ * リクエストを作成するヘルパー関数
+ */
+function createRequest(authHeader?: string): NextRequest {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (authHeader) {
+    headers['Authorization'] = authHeader;
+  }
+  return new NextRequest('http://localhost:3000/api/v1/auth/logout', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('POST /api/v1/auth/logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // デフォルトのモック動作を設定
+    mockClearAuthCookie.mockResolvedValue(undefined);
+  });
+
+  describe('IT-002-01: 正常ログアウト', () => {
+    it('有効なトークンで200とログアウトメッセージが返される', async () => {
+      // Arrange
+      const validToken = 'valid.jwt.token';
+      mockExtractTokenFromHeader.mockReturnValue(validToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: true,
+        payload: {
+          userId: 1,
+          email: 'yamada@example.com',
+          role: 'member',
+        },
+      });
+
+      const request = createRequest(`Bearer ${validToken}`);
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual({
+        message: 'ログアウトしました',
+      });
+
+      // モックの呼び出しを検証
+      expect(mockExtractTokenFromHeader).toHaveBeenCalledWith(`Bearer ${validToken}`);
+      expect(mockVerifyToken).toHaveBeenCalledWith(validToken);
+      expect(mockClearAuthCookie).toHaveBeenCalled();
+    });
+
+    it('managerロールのユーザーでも正常にログアウトできる', async () => {
+      // Arrange
+      const validToken = 'valid.jwt.token';
+      mockExtractTokenFromHeader.mockReturnValue(validToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: true,
+        payload: {
+          userId: 2,
+          email: 'manager@example.com',
+          role: 'manager',
+        },
+      });
+
+      const request = createRequest(`Bearer ${validToken}`);
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.message).toBe('ログアウトしました');
+      expect(mockClearAuthCookie).toHaveBeenCalled();
+    });
+
+    it('adminロールのユーザーでも正常にログアウトできる', async () => {
+      // Arrange
+      const validToken = 'valid.jwt.token';
+      mockExtractTokenFromHeader.mockReturnValue(validToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: true,
+        payload: {
+          userId: 3,
+          email: 'admin@example.com',
+          role: 'admin',
+        },
+      });
+
+      const request = createRequest(`Bearer ${validToken}`);
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.message).toBe('ログアウトしました');
+      expect(mockClearAuthCookie).toHaveBeenCalled();
+    });
+  });
+
+  describe('IT-002-02: トークンなし', () => {
+    it('Authorizationヘッダーなしで401とUNAUTHORIZEDが返される', async () => {
+      // Arrange
+      mockExtractTokenFromHeader.mockReturnValue(null);
+
+      const request = createRequest(); // Authorizationヘッダーなし
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('認証が必要です');
+
+      // clearAuthCookieは呼ばれない
+      expect(mockClearAuthCookie).not.toHaveBeenCalled();
+    });
+
+    it('空のAuthorizationヘッダーで401とUNAUTHORIZEDが返される', async () => {
+      // Arrange
+      mockExtractTokenFromHeader.mockReturnValue(null);
+
+      const request = createRequest('');
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+
+      // clearAuthCookieは呼ばれない
+      expect(mockClearAuthCookie).not.toHaveBeenCalled();
+    });
+
+    it('Bearer プレフィックスなしで401とUNAUTHORIZEDが返される', async () => {
+      // Arrange
+      mockExtractTokenFromHeader.mockReturnValue(null);
+
+      const request = createRequest('some.token.without.bearer');
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+
+      // clearAuthCookieは呼ばれない
+      expect(mockClearAuthCookie).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('IT-002-03: 無効なトークン', () => {
+    it('不正なトークンで401とUNAUTHORIZEDが返される', async () => {
+      // Arrange
+      const invalidToken = 'invalid.jwt.token';
+      mockExtractTokenFromHeader.mockReturnValue(invalidToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: false,
+        error: 'Invalid token signature',
+      });
+
+      const request = createRequest(`Bearer ${invalidToken}`);
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('Invalid token signature');
+
+      // clearAuthCookieは呼ばれない
+      expect(mockClearAuthCookie).not.toHaveBeenCalled();
+    });
+
+    it('期限切れトークンで401とUNAUTHORIZEDが返される', async () => {
+      // Arrange
+      const expiredToken = 'expired.jwt.token';
+      mockExtractTokenFromHeader.mockReturnValue(expiredToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: false,
+        error: 'Token has expired',
+      });
+
+      const request = createRequest(`Bearer ${expiredToken}`);
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('Token has expired');
+
+      // clearAuthCookieは呼ばれない
+      expect(mockClearAuthCookie).not.toHaveBeenCalled();
+    });
+
+    it('改ざんされたトークンで401とUNAUTHORIZEDが返される', async () => {
+      // Arrange
+      const tamperedToken = 'tampered.jwt.token';
+      mockExtractTokenFromHeader.mockReturnValue(tamperedToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: false,
+        error: 'Token verification failed',
+      });
+
+      const request = createRequest(`Bearer ${tamperedToken}`);
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+
+      // clearAuthCookieは呼ばれない
+      expect(mockClearAuthCookie).not.toHaveBeenCalled();
+    });
+
+    it('不正な形式のトークンで401とUNAUTHORIZEDが返される', async () => {
+      // Arrange
+      const malformedToken = 'malformed';
+      mockExtractTokenFromHeader.mockReturnValue(malformedToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: false,
+        error: 'Token is malformed',
+      });
+
+      const request = createRequest(`Bearer ${malformedToken}`);
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+
+      // clearAuthCookieは呼ばれない
+      expect(mockClearAuthCookie).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cookie削除の確認', () => {
+    it('ログアウト成功時にclearAuthCookieが正しく呼び出される', async () => {
+      // Arrange
+      const validToken = 'valid.jwt.token';
+      mockExtractTokenFromHeader.mockReturnValue(validToken);
+      mockVerifyToken.mockResolvedValue({
+        valid: true,
+        payload: {
+          userId: 1,
+          email: 'test@example.com',
+          role: 'member',
+        },
+      });
+
+      const request = createRequest(`Bearer ${validToken}`);
+
+      // Act
+      await POST(request);
+
+      // Assert
+      expect(mockClearAuthCookie).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/app/api/v1/auth/logout/route.ts
+++ b/src/app/api/v1/auth/logout/route.ts
@@ -1,0 +1,38 @@
+/**
+ * POST /api/v1/auth/logout
+ *
+ * ログアウト処理を行う。
+ *
+ * 処理フロー:
+ * 1. 認証ミドルウェア（withAuth）でトークン検証
+ * 2. 認証失敗 → UNAUTHORIZED
+ * 3. Cookieからトークン削除（clearAuthCookie）
+ * 4. 成功レスポンス返却
+ */
+
+import { NextRequest } from 'next/server';
+
+import { successResponse } from '@/lib/api/response';
+import { clearAuthCookie } from '@/lib/auth/cookie';
+import { withAuth } from '@/lib/auth/middleware';
+
+/**
+ * ログアウトレスポンスデータ型
+ */
+interface LogoutResponseData {
+  message: string;
+}
+
+export async function POST(request: NextRequest) {
+  return withAuth(request, async () => {
+    // Cookieからトークンを削除
+    await clearAuthCookie();
+
+    // 成功レスポンスを返却
+    const responseData: LogoutResponseData = {
+      message: 'ログアウトしました',
+    };
+
+    return successResponse(responseData);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: [path.resolve(__dirname, './src/test/setup.ts')],
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: [
+      'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'app/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+    ],
     exclude: ['node_modules', '.next', 'e2e'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- ログアウトAPIエンドポイント（POST /api/v1/auth/logout）を実装
- 認証ミドルウェア（withAuth）を使用してトークン検証
- 認証Cookie削除によるログアウト処理
- IT-002仕様に基づく11件のテストケースを実装

## 実装内容
### APIエンドポイント
- `src/app/api/v1/auth/logout/route.ts`

### テスト
- `src/app/api/v1/auth/logout/__tests__/route.test.ts`
  - IT-002-01: 正常ログアウト（有効なトークン）
  - IT-002-02: トークンなし（Authorizationヘッダーなし）
  - IT-002-03: 無効なトークン（不正なトークン形式）
  - 追加テスト: 期限切れトークン、Cookie削除検証など

## API仕様
### リクエスト
```
POST /api/v1/auth/logout
Authorization: Bearer {token}
```

### レスポンス（成功時）
```json
{
  "success": true,
  "data": {
    "message": "ログアウトしました"
  }
}
```

## Test plan
- [x] 全318件のテストがパス
- [x] lint チェック通過
- [x] build 成功

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)