### PR TITLE
feat: GET /api/v1/reports 日報一覧取得APIを実装 (#17)

### DIFF
--- a/src/app/api/v1/reports/__tests__/route.test.ts
+++ b/src/app/api/v1/reports/__tests__/route.test.ts
@@ -1,0 +1,923 @@
+/**
+ * GET /api/v1/reports APIのテスト
+ *
+ * @vitest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { generateToken } from '@/lib/auth/jwt';
+import { prisma } from '@/lib/prisma';
+import type { JwtPayload } from '@/types';
+
+import { GET } from '../route';
+
+// Prisma モック
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    salesPerson: {
+      findMany: vi.fn(),
+    },
+    dailyReport: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const TEST_SECRET = 'test-secret-key-for-testing-only-32-chars';
+
+// モックデータ: 営業担当者
+const mockMember = {
+  id: 1,
+  employeeCode: 'EMP001',
+  name: 'テスト太郎',
+  email: 'member@example.com',
+  role: 'member' as const,
+  managerId: 3,
+};
+
+const mockMember2 = {
+  id: 2,
+  employeeCode: 'EMP002',
+  name: 'テスト花子',
+  email: 'member2@example.com',
+  role: 'member' as const,
+  managerId: 3,
+};
+
+const mockManager = {
+  id: 3,
+  employeeCode: 'EMP003',
+  name: 'テスト課長',
+  email: 'manager@example.com',
+  role: 'manager' as const,
+  managerId: null,
+};
+
+const mockAdmin = {
+  id: 4,
+  employeeCode: 'EMP004',
+  name: 'テスト管理者',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  managerId: null,
+};
+
+// モックデータ: 日報
+const mockReports = [
+  {
+    id: 1,
+    reportDate: new Date('2025-01-15'),
+    status: 'submitted',
+    createdAt: new Date('2025-01-15T18:00:00Z'),
+    updatedAt: new Date('2025-01-15T18:30:00Z'),
+    salesPerson: { id: 1, name: 'テスト太郎' },
+    _count: { visitRecords: 3 },
+  },
+  {
+    id: 2,
+    reportDate: new Date('2025-01-14'),
+    status: 'reviewed',
+    createdAt: new Date('2025-01-14T18:00:00Z'),
+    updatedAt: new Date('2025-01-14T19:00:00Z'),
+    salesPerson: { id: 1, name: 'テスト太郎' },
+    _count: { visitRecords: 2 },
+  },
+  {
+    id: 3,
+    reportDate: new Date('2025-01-15'),
+    status: 'draft',
+    createdAt: new Date('2025-01-15T17:00:00Z'),
+    updatedAt: new Date('2025-01-15T17:00:00Z'),
+    salesPerson: { id: 2, name: 'テスト花子' },
+    _count: { visitRecords: 4 },
+  },
+  {
+    id: 4,
+    reportDate: new Date('2025-01-13'),
+    status: 'submitted',
+    createdAt: new Date('2025-01-13T18:00:00Z'),
+    updatedAt: new Date('2025-01-13T18:00:00Z'),
+    salesPerson: { id: 3, name: 'テスト課長' },
+    _count: { visitRecords: 1 },
+  },
+];
+
+/**
+ * テスト用のリクエストを作成
+ */
+function createRequest(token?: string, params?: Record<string, string | undefined>): NextRequest {
+  const url = new URL('http://localhost:3000/api/v1/reports');
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) {
+        url.searchParams.set(key, value);
+      }
+    });
+  }
+
+  if (token) {
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('Authorization', `Bearer ${token}`);
+
+    return new NextRequest(url, {
+      method: 'GET',
+      headers,
+    });
+  }
+
+  return new NextRequest(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+describe('GET /api/v1/reports', () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+  });
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('認証エラー', () => {
+    it('トークンなしの場合は401を返す', async () => {
+      const request = createRequest(); // トークンなし
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('認証が必要です');
+    });
+
+    it('無効なトークンの場合は401を返す', async () => {
+      const request = createRequest('invalid-token');
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+    });
+  });
+
+  describe('IT-010-01: 一覧取得（一般営業）', () => {
+    it('自分の日報のみ取得できる', async () => {
+      // モック設定
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      // 自分の日報のみ（id: 1, 2）
+      const memberReports = mockReports.filter((r) => r.salesPerson.id === mockMember.id);
+      countMock.mockResolvedValueOnce(memberReports.length);
+      findManyMock.mockResolvedValueOnce(memberReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token);
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(2);
+
+      // 全てのデータが自分のものであることを確認
+      data.data.forEach((report: { sales_person: { id: number } }) => {
+        expect(report.sales_person.id).toBe(mockMember.id);
+      });
+
+      // Prismaが正しい条件で呼び出されたことを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { salesPersonId: { in: [mockMember.id] } },
+      });
+    });
+
+    it('他人の日報は取得できない（sales_person_id指定で空結果）', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      // 他人のIDを指定
+      const request = createRequest(token, { sales_person_id: '2' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(0);
+      expect(data.pagination.total_count).toBe(0);
+    });
+  });
+
+  describe('IT-010-02: 一覧取得（上長）', () => {
+    it('自分と部下の日報を取得できる', async () => {
+      // モック設定
+      const salesPersonFindManyMock = vi.mocked(prisma.salesPerson.findMany);
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      // 部下のリスト
+      salesPersonFindManyMock.mockResolvedValueOnce([
+        { id: mockMember.id },
+        { id: mockMember2.id },
+      ] as never);
+
+      // 自分と部下の日報（id: 1, 2, 3, 4）
+      const managerReports = mockReports.filter(
+        (r) =>
+          r.salesPerson.id === mockManager.id ||
+          r.salesPerson.id === mockMember.id ||
+          r.salesPerson.id === mockMember2.id
+      );
+      countMock.mockResolvedValueOnce(managerReports.length);
+      findManyMock.mockResolvedValueOnce(managerReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockManager.id,
+        email: mockManager.email,
+        role: mockManager.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token);
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(4);
+
+      // 部下のIDリストを取得するクエリが正しく呼ばれたことを確認
+      expect(salesPersonFindManyMock).toHaveBeenCalledWith({
+        where: { managerId: mockManager.id },
+        select: { id: true },
+      });
+
+      // 正しい条件でフィルタされていることを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: {
+          salesPersonId: { in: [mockManager.id, mockMember.id, mockMember2.id] },
+        },
+      });
+    });
+
+    it('部下の日報を個別に取得できる', async () => {
+      // モック設定
+      const salesPersonFindManyMock = vi.mocked(prisma.salesPerson.findMany);
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      // 部下のリスト
+      salesPersonFindManyMock.mockResolvedValueOnce([
+        { id: mockMember.id },
+        { id: mockMember2.id },
+      ] as never);
+
+      // 部下の日報のみ
+      const subordinateReports = mockReports.filter((r) => r.salesPerson.id === mockMember.id);
+      countMock.mockResolvedValueOnce(subordinateReports.length);
+      findManyMock.mockResolvedValueOnce(subordinateReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockManager.id,
+        email: mockManager.email,
+        role: mockManager.role,
+      };
+      const token = await generateToken(payload);
+
+      // 部下のIDを指定
+      const request = createRequest(token, { sales_person_id: String(mockMember.id) });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(2);
+      data.data.forEach((report: { sales_person: { id: number } }) => {
+        expect(report.sales_person.id).toBe(mockMember.id);
+      });
+    });
+  });
+
+  describe('IT-010-03: 一覧取得（管理者）', () => {
+    it('全員の日報を取得できる', async () => {
+      // モック設定
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      countMock.mockResolvedValueOnce(mockReports.length);
+      findManyMock.mockResolvedValueOnce(mockReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: mockAdmin.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token);
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(4);
+
+      // フィルタなしで呼び出されていることを確認
+      expect(countMock).toHaveBeenCalledWith({ where: {} });
+    });
+
+    it('特定の営業担当者の日報のみを取得できる', async () => {
+      // モック設定
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const filteredReports = mockReports.filter((r) => r.salesPerson.id === mockMember.id);
+      countMock.mockResolvedValueOnce(filteredReports.length);
+      findManyMock.mockResolvedValueOnce(filteredReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: mockAdmin.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { sales_person_id: String(mockMember.id) });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(2);
+
+      // 正しい条件で呼び出されていることを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { salesPersonId: mockMember.id },
+      });
+    });
+  });
+
+  describe('IT-010-04: 日付フィルタ', () => {
+    it('開始日のみ指定した場合、その日以降の日報を取得する', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      // 2025-01-14以降の日報
+      const filteredReports = mockReports.filter(
+        (r) => r.salesPerson.id === mockMember.id && r.reportDate >= new Date('2025-01-14')
+      );
+      countMock.mockResolvedValueOnce(filteredReports.length);
+      findManyMock.mockResolvedValueOnce(filteredReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { start_date: '2025-01-14' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // countの呼び出し引数を確認
+      const countCall = countMock.mock.calls[0][0];
+      expect(countCall.where.reportDate).toBeDefined();
+      expect(countCall.where.reportDate.gte).toBeInstanceOf(Date);
+    });
+
+    it('終了日のみ指定した場合、その日以前の日報を取得する', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const filteredReports = mockReports.filter(
+        (r) => r.salesPerson.id === mockMember.id && r.reportDate <= new Date('2025-01-14')
+      );
+      countMock.mockResolvedValueOnce(filteredReports.length);
+      findManyMock.mockResolvedValueOnce(filteredReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { end_date: '2025-01-14' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // countの呼び出し引数を確認
+      const countCall = countMock.mock.calls[0][0];
+      expect(countCall.where.reportDate).toBeDefined();
+      expect(countCall.where.reportDate.lte).toBeInstanceOf(Date);
+    });
+
+    it('開始日と終了日を指定した場合、その範囲の日報を取得する', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const filteredReports = mockReports.filter(
+        (r) =>
+          r.salesPerson.id === mockMember.id &&
+          r.reportDate >= new Date('2025-01-14') &&
+          r.reportDate <= new Date('2025-01-15')
+      );
+      countMock.mockResolvedValueOnce(filteredReports.length);
+      findManyMock.mockResolvedValueOnce(filteredReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, {
+        start_date: '2025-01-14',
+        end_date: '2025-01-15',
+      });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // countの呼び出し引数を確認
+      const countCall = countMock.mock.calls[0][0];
+      expect(countCall.where.reportDate.gte).toBeInstanceOf(Date);
+      expect(countCall.where.reportDate.lte).toBeInstanceOf(Date);
+    });
+
+    it('開始日が終了日より後の場合はバリデーションエラーを返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, {
+        start_date: '2025-01-15',
+        end_date: '2025-01-14',
+      });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toContain('開始日は終了日以前');
+    });
+  });
+
+  describe('IT-010-05: ステータスフィルタ', () => {
+    it('submittedステータスの日報のみ取得できる', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const filteredReports = mockReports.filter(
+        (r) => r.salesPerson.id === mockMember.id && r.status === 'submitted'
+      );
+      countMock.mockResolvedValueOnce(filteredReports.length);
+      findManyMock.mockResolvedValueOnce(filteredReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { status: 'submitted' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // countの呼び出し引数を確認
+      const countCall = countMock.mock.calls[0][0];
+      expect(countCall.where.status).toBe('submitted');
+    });
+
+    it('draftステータスの日報のみ取得できる', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const filteredReports = mockReports.filter(
+        (r) => r.salesPerson.id === mockMember.id && r.status === 'draft'
+      );
+      countMock.mockResolvedValueOnce(filteredReports.length);
+      findManyMock.mockResolvedValueOnce(filteredReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { status: 'draft' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      const countCall = countMock.mock.calls[0][0];
+      expect(countCall.where.status).toBe('draft');
+    });
+
+    it('reviewedステータスの日報のみ取得できる', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const filteredReports = mockReports.filter(
+        (r) => r.salesPerson.id === mockMember.id && r.status === 'reviewed'
+      );
+      countMock.mockResolvedValueOnce(filteredReports.length);
+      findManyMock.mockResolvedValueOnce(filteredReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { status: 'reviewed' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      const countCall = countMock.mock.calls[0][0];
+      expect(countCall.where.status).toBe('reviewed');
+    });
+
+    it('無効なステータスの場合はバリデーションエラーを返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { status: 'invalid_status' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('IT-010-06: ページネーション', () => {
+    it('デフォルトのページネーション（page=1, per_page=20）で取得する', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const memberReports = mockReports.filter((r) => r.salesPerson.id === mockMember.id);
+      countMock.mockResolvedValueOnce(memberReports.length);
+      findManyMock.mockResolvedValueOnce(memberReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token);
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.pagination).toEqual({
+        current_page: 1,
+        per_page: 20,
+        total_pages: 1,
+        total_count: 2,
+      });
+
+      // findManyの呼び出し引数を確認
+      const findManyCall = findManyMock.mock.calls[0][0];
+      expect(findManyCall.skip).toBe(0);
+      expect(findManyCall.take).toBe(20);
+    });
+
+    it('page=2, per_page=10で2ページ目を取得する', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      // 総件数25件を想定
+      countMock.mockResolvedValueOnce(25);
+      findManyMock.mockResolvedValueOnce(mockReports.slice(0, 2) as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: mockAdmin.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { page: '2', per_page: '10' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.pagination).toEqual({
+        current_page: 2,
+        per_page: 10,
+        total_pages: 3,
+        total_count: 25,
+      });
+
+      // findManyの呼び出し引数を確認
+      const findManyCall = findManyMock.mock.calls[0][0];
+      expect(findManyCall.skip).toBe(10); // (2-1) * 10 = 10
+      expect(findManyCall.take).toBe(10);
+    });
+
+    it('per_page=100を超える値はバリデーションエラーを返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { per_page: '101' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toContain('100以下');
+    });
+
+    it('page=0はバリデーションエラーを返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { page: '0' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('per_page=0はバリデーションエラーを返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { per_page: '0' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('レスポンスフォーマット', () => {
+    it('レスポンスデータが正しいフォーマットで返される', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const memberReports = mockReports.filter((r) => r.salesPerson.id === mockMember.id);
+      countMock.mockResolvedValueOnce(memberReports.length);
+      findManyMock.mockResolvedValueOnce(memberReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token);
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // 最初のデータのフォーマットを確認
+      const firstReport = data.data[0];
+      expect(firstReport).toHaveProperty('id');
+      expect(firstReport).toHaveProperty('report_date');
+      expect(firstReport).toHaveProperty('sales_person');
+      expect(firstReport.sales_person).toHaveProperty('id');
+      expect(firstReport.sales_person).toHaveProperty('name');
+      expect(firstReport).toHaveProperty('visit_count');
+      expect(firstReport).toHaveProperty('status');
+      expect(firstReport).toHaveProperty('created_at');
+      expect(firstReport).toHaveProperty('updated_at');
+
+      // 日付フォーマットの確認（YYYY-MM-DD）
+      expect(firstReport.report_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      // ISO8601形式の確認
+      expect(firstReport.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(firstReport.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('日報が0件の場合、空配列とページネーション情報を返す', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      countMock.mockResolvedValueOnce(0);
+      findManyMock.mockResolvedValueOnce([]);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token);
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual([]);
+      expect(data.pagination).toEqual({
+        current_page: 1,
+        per_page: 20,
+        total_pages: 0,
+        total_count: 0,
+      });
+    });
+  });
+
+  describe('バリデーションエラー', () => {
+    it('不正な日付フォーマット（start_date）の場合は422を返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { start_date: 'invalid-date' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toContain('YYYY-MM-DD');
+    });
+
+    it('不正な日付フォーマット（end_date）の場合は422を返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { end_date: '2025/01/15' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toContain('YYYY-MM-DD');
+    });
+
+    it('不正なsales_person_idの場合は422を返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: mockAdmin.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, { sales_person_id: 'abc' });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('複合条件', () => {
+    it('日付、ステータス、ページネーションを組み合わせて検索できる', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      countMock.mockResolvedValueOnce(1);
+      findManyMock.mockResolvedValueOnce([mockReports[0]] as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token, {
+        start_date: '2025-01-14',
+        end_date: '2025-01-15',
+        status: 'submitted',
+        page: '1',
+        per_page: '10',
+      });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // countの呼び出し引数を確認
+      const countCall = countMock.mock.calls[0][0];
+      expect(countCall.where.salesPersonId).toBeDefined();
+      expect(countCall.where.reportDate).toBeDefined();
+      expect(countCall.where.status).toBe('submitted');
+
+      // findManyの呼び出し引数を確認
+      const findManyCall = findManyMock.mock.calls[0][0];
+      expect(findManyCall.skip).toBe(0);
+      expect(findManyCall.take).toBe(10);
+    });
+  });
+
+  describe('ソート順', () => {
+    it('日報は報告日の降順でソートされる', async () => {
+      const countMock = vi.mocked(prisma.dailyReport.count);
+      const findManyMock = vi.mocked(prisma.dailyReport.findMany);
+
+      const memberReports = mockReports.filter((r) => r.salesPerson.id === mockMember.id);
+      countMock.mockResolvedValueOnce(memberReports.length);
+      findManyMock.mockResolvedValueOnce(memberReports as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+      };
+      const token = await generateToken(payload);
+
+      const request = createRequest(token);
+      await GET(request);
+
+      // findManyの呼び出し引数を確認
+      const findManyCall = findManyMock.mock.calls[0][0];
+      expect(findManyCall.orderBy).toEqual([{ reportDate: 'desc' }, { id: 'desc' }]);
+    });
+  });
+});

--- a/src/app/api/v1/reports/route.ts
+++ b/src/app/api/v1/reports/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  paginatedResponse,
+  errorResponse,
+  calculatePagination,
+  calculateOffset,
+} from '@/lib/api/response';
+import { withAuth, type AuthUser } from '@/lib/auth/middleware';
+import { prisma } from '@/lib/prisma';
+import { dailyReportQuerySchema } from '@/lib/validations/daily-report';
+
+/**
+ * 日付文字列をローカルタイムゾーンのDateオブジェクトに変換
+ * 日付の始まり（00:00:00）を返す
+ */
+function parseLocalDateStart(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day, 0, 0, 0, 0);
+}
+
+/**
+ * 日付文字列をローカルタイムゾーンのDateオブジェクトに変換
+ * 日付の終わり（23:59:59.999）を返す
+ */
+function parseLocalDateEnd(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day, 23, 59, 59, 999);
+}
+
+/**
+ * 権限に基づいて閲覧可能な営業担当者IDのリストを取得
+ *
+ * - member: 自分のみ
+ * - manager: 自分 + 部下
+ * - admin: 全員（nullを返す = フィルタなし）
+ */
+async function getViewableSalesPersonIds(user: AuthUser): Promise<number[] | null> {
+  // adminは全員の日報を閲覧可能
+  if (user.role === 'admin') {
+    return null; // フィルタなし
+  }
+
+  // memberは自分の日報のみ
+  if (user.role === 'member') {
+    return [user.id];
+  }
+
+  // managerは自分 + 部下の日報
+  const subordinates = await prisma.salesPerson.findMany({
+    where: { managerId: user.id },
+    select: { id: true },
+  });
+
+  const subordinateIds = subordinates.map((s) => s.id);
+  return [user.id, ...subordinateIds];
+}
+
+/**
+ * GET /api/v1/reports
+ * 日報一覧を取得する
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return withAuth(request, async (req, user: AuthUser): Promise<NextResponse> => {
+    // クエリパラメータを取得
+    const searchParams = req.nextUrl.searchParams;
+    const queryParams = {
+      startDate: searchParams.get('start_date') || undefined,
+      endDate: searchParams.get('end_date') || undefined,
+      salesPersonId: searchParams.get('sales_person_id') || undefined,
+      status: searchParams.get('status') || undefined,
+      page: searchParams.get('page') || undefined,
+      perPage: searchParams.get('per_page') || undefined,
+    };
+
+    // バリデーション
+    const validationResult = dailyReportQuerySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      // Zodのエラーメッセージを取得（errors配列またはissues配列を確認）
+      const issues = validationResult.error.issues;
+      const firstError = issues[0];
+      return errorResponse('VALIDATION_ERROR', firstError?.message || '入力値が不正です');
+    }
+
+    const { startDate, endDate, salesPersonId, status, page, perPage } = validationResult.data;
+
+    // 権限に基づいて閲覧可能な営業担当者IDを取得
+    const viewableSalesPersonIds = await getViewableSalesPersonIds(user);
+
+    // 検索条件を構築
+    const whereCondition: {
+      salesPersonId?: number | { in: number[] };
+      reportDate?: { gte?: Date; lte?: Date };
+      status?: 'draft' | 'submitted' | 'reviewed';
+    } = {};
+
+    // 権限に基づくフィルタ
+    if (viewableSalesPersonIds !== null) {
+      // 特定のsales_person_idが指定された場合、権限チェック
+      if (salesPersonId !== undefined) {
+        if (!viewableSalesPersonIds.includes(salesPersonId)) {
+          // 指定されたIDが閲覧可能範囲外の場合、空の結果を返す
+          return paginatedResponse([], calculatePagination(page, perPage, 0));
+        }
+        whereCondition.salesPersonId = salesPersonId;
+      } else {
+        whereCondition.salesPersonId = { in: viewableSalesPersonIds };
+      }
+    } else {
+      // adminの場合、sales_person_idが指定されていれば使用
+      if (salesPersonId !== undefined) {
+        whereCondition.salesPersonId = salesPersonId;
+      }
+    }
+
+    // 日付フィルタ
+    if (startDate || endDate) {
+      whereCondition.reportDate = {};
+      if (startDate) {
+        whereCondition.reportDate.gte = parseLocalDateStart(startDate);
+      }
+      if (endDate) {
+        whereCondition.reportDate.lte = parseLocalDateEnd(endDate);
+      }
+    }
+
+    // ステータスフィルタ
+    if (status) {
+      whereCondition.status = status;
+    }
+
+    // 総件数を取得
+    const totalCount = await prisma.dailyReport.count({
+      where: whereCondition,
+    });
+
+    // ページネーション計算
+    const pagination = calculatePagination(page, perPage, totalCount);
+    const offset = calculateOffset(page, perPage);
+
+    // 日報一覧を取得（訪問記録件数含む）
+    const reports = await prisma.dailyReport.findMany({
+      where: whereCondition,
+      select: {
+        id: true,
+        reportDate: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+        salesPerson: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        _count: {
+          select: {
+            visitRecords: true,
+          },
+        },
+      },
+      orderBy: [{ reportDate: 'desc' }, { id: 'desc' }],
+      skip: offset,
+      take: perPage,
+    });
+
+    // レスポンスデータを構築
+    const responseData = reports.map((report) => ({
+      id: report.id,
+      report_date: report.reportDate.toISOString().split('T')[0],
+      sales_person: {
+        id: report.salesPerson.id,
+        name: report.salesPerson.name,
+      },
+      visit_count: report._count.visitRecords,
+      status: report.status,
+      created_at: report.createdAt.toISOString(),
+      updated_at: report.updatedAt.toISOString(),
+    }));
+
+    return paginatedResponse(responseData, pagination);
+  });
+}


### PR DESCRIPTION
## Summary

Issue #17 に基づき、日報一覧取得API (`GET /api/v1/reports`) を実装しました。

### 実装内容

#### エンドポイント
`GET /api/v1/reports`

#### クエリパラメータ
| パラメータ | 型 | 説明 |
|------------|-----|------|
| start_date | date | 検索開始日（YYYY-MM-DD） |
| end_date | date | 検索終了日（YYYY-MM-DD） |
| sales_person_id | integer | 営業担当者ID |
| status | string | ステータス（draft/submitted/reviewed） |
| page | integer | ページ番号（デフォルト: 1） |
| per_page | integer | 1ページあたりの件数（デフォルト: 20, 最大: 100） |

#### 権限による閲覧制限
| 権限 | 閲覧可能範囲 |
|------|-------------|
| member | 自分の日報のみ |
| manager | 自分+部下の日報 |
| admin | 全員の日報 |

#### レスポンス形式
```json
{
  "success": true,
  "data": [
    {
      "id": 1,
      "report_date": "2025-01-15",
      "sales_person": { "id": 1, "name": "山田太郎" },
      "visit_count": 3,
      "status": "submitted",
      "created_at": "2025-01-15T18:00:00.000Z",
      "updated_at": "2025-01-15T18:30:00.000Z"
    }
  ],
  "pagination": {
    "current_page": 1,
    "per_page": 20,
    "total_pages": 5,
    "total_count": 100
  }
}
```

### テスト

28件のテストケースを追加:
- 認証エラー（トークンなし、無効なトークン）
- IT-010-01〜03: 権限による閲覧制限
- IT-010-04: 日付フィルタ
- IT-010-05: ステータスフィルタ
- IT-010-06: ページネーション
- バリデーションエラー
- 複合条件検索
- ソート順検証

### 完了条件

- [x] APIエンドポイントが実装されている
- [x] フィルタリングが動作する
- [x] ページネーションが動作する
- [x] 権限に応じた閲覧制限が機能する

## Test plan

- [x] `npm run test:run` - 全413件のテストがパス

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)