### PR TITLE
feat: PUT /api/v1/reports/{id} エンドポイントを実装 (#20)

### DIFF
--- a/src/app/api/v1/reports/[id]/route.ts
+++ b/src/app/api/v1/reports/[id]/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { successResponse, errorResponse } from '@/lib/api/response';
-import { withAuth, type AuthUser, canViewReport } from '@/lib/auth/middleware';
+import { withAuth, type AuthUser, canViewReport, canEditReport } from '@/lib/auth/middleware';
 import { prisma } from '@/lib/prisma';
 import { idParamSchema } from '@/lib/validations/common';
+import { updateDailyReportSchema } from '@/lib/validations/daily-report';
 
 /**
  * GET /api/v1/reports/{id}
@@ -104,6 +105,288 @@ export async function GET(
       })),
       created_at: report.createdAt.toISOString(),
       updated_at: report.updatedAt.toISOString(),
+    };
+
+    return successResponse(responseData);
+  });
+}
+
+/**
+ * 日付文字列をローカルタイムゾーンのDateオブジェクトに変換
+ * 日付の始まり（00:00:00）を返す
+ */
+function parseLocalDateStart(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day, 0, 0, 0, 0);
+}
+
+/**
+ * リクエストボディをスキーマ用の形式に変換
+ * snake_case -> camelCase
+ */
+interface UpdateReportRequestBody {
+  report_date?: string;
+  problem?: string;
+  plan?: string;
+  status?: string;
+  visit_records?: Array<{
+    id?: number;
+    customer_id?: number;
+    visit_time?: string;
+    content?: string;
+  }>;
+}
+
+function transformRequestBody(body: UpdateReportRequestBody) {
+  return {
+    reportDate: body.report_date,
+    problem: body.problem,
+    plan: body.plan,
+    status: body.status,
+    visitRecords: body.visit_records?.map((record) => ({
+      id: record.id,
+      customerId: record.customer_id,
+      visitTime: record.visit_time,
+      content: record.content,
+    })),
+  };
+}
+
+/**
+ * PUT /api/v1/reports/{id}
+ * 日報を更新する
+ */
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withAuth(request, async (_req, user: AuthUser): Promise<NextResponse> => {
+    // パスパラメータを取得
+    const params = await context.params;
+    const idParam = params.id;
+
+    // IDのバリデーション
+    const idValidationResult = idParamSchema.safeParse(idParam);
+    if (!idValidationResult.success) {
+      return errorResponse('VALIDATION_ERROR', 'IDは正の整数で指定してください');
+    }
+
+    const reportId = idValidationResult.data;
+
+    // 日報の存在チェック
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: { id: reportId },
+      include: {
+        visitRecords: {
+          select: { id: true },
+        },
+      },
+    });
+
+    if (!existingReport) {
+      return errorResponse('NOT_FOUND', '日報が見つかりません');
+    }
+
+    // 本人チェック
+    if (!canEditReport(user, existingReport.salesPersonId)) {
+      return errorResponse('FORBIDDEN', 'この日報を編集する権限がありません');
+    }
+
+    // リクエストボディを取得
+    let body: UpdateReportRequestBody;
+    try {
+      body = await request.json();
+    } catch {
+      return errorResponse('BAD_REQUEST', 'リクエストボディが不正です');
+    }
+
+    // snake_case -> camelCase 変換
+    const transformedBody = transformRequestBody(body);
+
+    // バリデーション
+    const validationResult = updateDailyReportSchema.safeParse(transformedBody);
+    if (!validationResult.success) {
+      const issues = validationResult.error.issues;
+      const firstError = issues[0];
+      return errorResponse('VALIDATION_ERROR', firstError?.message || '入力値が不正です');
+    }
+
+    const { reportDate, problem, plan, status, visitRecords } = validationResult.data;
+
+    // 日付変更がある場合、重複チェック
+    if (reportDate) {
+      const newReportDateObj = parseLocalDateStart(reportDate);
+      const existingReportDate = existingReport.reportDate;
+
+      // 日付が変更された場合のみ重複チェック
+      if (newReportDateObj.getTime() !== existingReportDate.getTime()) {
+        const duplicateReport = await prisma.dailyReport.findUnique({
+          where: {
+            salesPersonId_reportDate: {
+              salesPersonId: user.id,
+              reportDate: newReportDateObj,
+            },
+          },
+        });
+
+        if (duplicateReport) {
+          return errorResponse('CONFLICT', 'この日付の日報は既に存在します');
+        }
+      }
+    }
+
+    // 訪問記録が指定されている場合、顧客IDの存在確認
+    if (visitRecords && visitRecords.length > 0) {
+      const customerIds = visitRecords.map((record) => record.customerId);
+      const existingCustomers = await prisma.customer.findMany({
+        where: {
+          id: { in: customerIds },
+          isActive: true,
+        },
+        select: { id: true },
+      });
+      const existingCustomerIds = new Set(existingCustomers.map((c) => c.id));
+
+      for (const customerId of customerIds) {
+        if (!existingCustomerIds.has(customerId)) {
+          return errorResponse('VALIDATION_ERROR', `顧客ID ${customerId} は存在しないか無効です`);
+        }
+      }
+    }
+
+    // 既存の訪問記録IDを取得
+    const existingVisitRecordIds = new Set(existingReport.visitRecords.map((v) => v.id));
+
+    // トランザクションで日報と訪問記録を更新
+    const updatedReport = await prisma.$transaction(async (tx) => {
+      // 日報レコードを更新
+      const updateData: {
+        reportDate?: Date;
+        problem?: string | null;
+        plan?: string | null;
+        status?: 'draft' | 'submitted' | 'reviewed';
+      } = {};
+
+      if (reportDate !== undefined) {
+        updateData.reportDate = parseLocalDateStart(reportDate);
+      }
+      if (problem !== undefined) {
+        updateData.problem = problem || null;
+      }
+      if (plan !== undefined) {
+        updateData.plan = plan || null;
+      }
+      if (status !== undefined) {
+        updateData.status = status;
+      }
+
+      await tx.dailyReport.update({
+        where: { id: reportId },
+        data: updateData,
+      });
+
+      // 訪問記録の処理
+      if (visitRecords !== undefined) {
+        // リクエストに含まれる既存のIDを収集
+        const requestVisitRecordIds = new Set(
+          visitRecords.filter((v) => v.id !== undefined).map((v) => v.id as number)
+        );
+
+        // リクエストに含まれていない既存レコードを削除
+        const idsToDelete = [...existingVisitRecordIds].filter(
+          (id) => !requestVisitRecordIds.has(id)
+        );
+        if (idsToDelete.length > 0) {
+          await tx.visitRecord.deleteMany({
+            where: {
+              id: { in: idsToDelete },
+              dailyReportId: reportId,
+            },
+          });
+        }
+
+        // 訪問記録の更新・追加
+        for (let index = 0; index < visitRecords.length; index++) {
+          const record = visitRecords[index];
+
+          if (record.id !== undefined && existingVisitRecordIds.has(record.id)) {
+            // 既存レコードの更新
+            await tx.visitRecord.update({
+              where: { id: record.id },
+              data: {
+                customerId: record.customerId,
+                visitTime: record.visitTime || null,
+                content: record.content,
+                sortOrder: index,
+              },
+            });
+          } else {
+            // 新規レコードの追加
+            await tx.visitRecord.create({
+              data: {
+                dailyReportId: reportId,
+                customerId: record.customerId,
+                visitTime: record.visitTime || null,
+                content: record.content,
+                sortOrder: index,
+              },
+            });
+          }
+        }
+      }
+
+      // 更新後のデータを取得
+      return tx.dailyReport.findUnique({
+        where: { id: reportId },
+        include: {
+          salesPerson: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          visitRecords: {
+            include: {
+              customer: {
+                select: {
+                  id: true,
+                  name: true,
+                },
+              },
+            },
+            orderBy: { sortOrder: 'asc' },
+          },
+        },
+      });
+    });
+
+    if (!updatedReport) {
+      return errorResponse('INTERNAL_ERROR', '日報の更新に失敗しました');
+    }
+
+    // レスポンスデータを構築
+    const responseData = {
+      id: updatedReport.id,
+      report_date: updatedReport.reportDate.toISOString().split('T')[0],
+      sales_person: {
+        id: updatedReport.salesPerson.id,
+        name: updatedReport.salesPerson.name,
+      },
+      problem: updatedReport.problem,
+      plan: updatedReport.plan,
+      status: updatedReport.status,
+      visit_records: updatedReport.visitRecords.map((record) => ({
+        id: record.id,
+        customer: {
+          id: record.customer.id,
+          name: record.customer.name,
+        },
+        visit_time: record.visitTime,
+        content: record.content,
+        sort_order: record.sortOrder,
+      })),
+      created_at: updatedReport.createdAt.toISOString(),
+      updated_at: updatedReport.updatedAt.toISOString(),
     };
 
     return successResponse(responseData);


### PR DESCRIPTION
## Summary

- PUT /api/v1/reports/{id} エンドポイントを実装
- 日報更新機能（訪問記録の差分更新含む）
- 本人のみ編集可能な権限チェック

## 変更内容

### API実装 (`src/app/api/v1/reports/[id]/route.ts`)

#### 主な機能
- **認証**: `withAuth`ミドルウェアによるBearer Token認証
- **権限チェック**: 本人のみ編集可能（`canEditReport`を使用）
- **IDバリデーション**: `idParamSchema`によるパスパラメータ検証
- **リクエストボディ変換**: snake_case → camelCase変換
- **重複日付チェック**: 日付変更時に他の日報と重複しないか確認

#### 訪問記録の差分更新
- `id`あり: 既存レコードを更新
- `id`なし: 新規レコードを追加
- リクエストに含まれない既存レコード: 削除

#### トランザクション処理
1. 日報レコード更新
2. 削除対象の訪問記録を削除
3. 既存訪問記録を更新
4. 新規訪問記録を追加
5. 更新後のデータを取得

### テストケース (`src/app/api/v1/reports/[id]/__tests__/route.test.ts`)

| テストID | 内容 | 結果 |
|----------|------|------|
| IT-013-01 | 正常更新 | 200 |
| IT-013-02 | 訪問記録追加 | 200 |
| IT-013-03 | 訪問記録削除（リクエストから除外） | 200 |
| IT-013-04 | 他人の日報更新 | 403 FORBIDDEN |
| IT-013-05 | ステータス変更（draft → submitted） | 200 |
| 追加 | 存在しない日報 | 404 NOT_FOUND |
| 追加 | IDが不正 | 422 VALIDATION_ERROR |
| 追加 | 既存訪問記録の更新 | 200 |
| 追加 | 部分更新（一部フィールドのみ） | 200 |

## Test plan

- [x] 全テスト通過（480件）
- [x] 既存テストへの影響なし
- [x] ESLintエラーなし

## 関連Issue

closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)