### PR TITLE
feat: 顧客一覧取得API (GET /api/v1/customers) を追加

### DIFF
--- a/src/app/api/v1/customers/route.ts
+++ b/src/app/api/v1/customers/route.ts
@@ -6,7 +6,9 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 
-import prisma from '@/lib/prisma';
+import { successResponse, errorResponse } from '@/lib/api/response';
+import { withAuth, type AuthUser } from '@/lib/auth/middleware';
+import { prisma } from '@/lib/prisma';
 
 /**
  * 顧客一覧取得
@@ -15,69 +17,59 @@ import prisma from '@/lib/prisma';
  * @query keyword - 顧客名・顧客コードで部分一致検索
  */
 export async function GET(request: NextRequest) {
-  try {
-    const searchParams = request.nextUrl.searchParams;
-    const isActive = searchParams.get('is_active');
-    const keyword = searchParams.get('keyword');
+  return withAuth(request, async (req, _user: AuthUser): Promise<NextResponse> => {
+    try {
+      const searchParams = req.nextUrl.searchParams;
+      const isActive = searchParams.get('is_active');
+      const keyword = searchParams.get('keyword');
 
-    // フィルタ条件を構築
-    const where: {
-      isActive?: boolean;
-      OR?: Array<{
-        name?: { contains: string; mode: 'insensitive' };
-        customerCode?: { contains: string; mode: 'insensitive' };
-      }>;
-    } = {};
+      // フィルタ条件を構築
+      const where: {
+        isActive?: boolean;
+        OR?: Array<{
+          name?: { contains: string; mode: 'insensitive' };
+          customerCode?: { contains: string; mode: 'insensitive' };
+        }>;
+      } = {};
 
-    if (isActive !== null) {
-      where.isActive = isActive === 'true';
-    }
+      if (isActive !== null) {
+        where.isActive = isActive === 'true';
+      }
 
-    if (keyword) {
-      where.OR = [
-        { name: { contains: keyword, mode: 'insensitive' } },
-        { customerCode: { contains: keyword, mode: 'insensitive' } },
-      ];
-    }
+      if (keyword) {
+        where.OR = [
+          { name: { contains: keyword, mode: 'insensitive' } },
+          { customerCode: { contains: keyword, mode: 'insensitive' } },
+        ];
+      }
 
-    const customers = await prisma.customer.findMany({
-      where,
-      orderBy: { customerCode: 'asc' },
-      select: {
-        id: true,
-        customerCode: true,
-        name: true,
-        address: true,
-        phone: true,
-        isActive: true,
-      },
-    });
-
-    // APIレスポンス形式に変換
-    const data = customers.map((customer) => ({
-      id: customer.id,
-      customer_code: customer.customerCode,
-      name: customer.name,
-      address: customer.address,
-      phone: customer.phone,
-      is_active: customer.isActive,
-    }));
-
-    return NextResponse.json({
-      success: true,
-      data,
-    });
-  } catch (error) {
-    console.error('Failed to fetch customers:', error);
-    return NextResponse.json(
-      {
-        success: false,
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: '顧客一覧の取得に失敗しました',
+      const customers = await prisma.customer.findMany({
+        where,
+        orderBy: { customerCode: 'asc' },
+        select: {
+          id: true,
+          customerCode: true,
+          name: true,
+          address: true,
+          phone: true,
+          isActive: true,
         },
-      },
-      { status: 500 }
-    );
-  }
+      });
+
+      // APIレスポンス形式に変換
+      const data = customers.map((customer) => ({
+        id: customer.id,
+        customer_code: customer.customerCode,
+        name: customer.name,
+        address: customer.address,
+        phone: customer.phone,
+        is_active: customer.isActive,
+      }));
+
+      return successResponse(data);
+    } catch (error) {
+      console.error('Failed to fetch customers:', error);
+      return errorResponse('INTERNAL_ERROR', '顧客一覧の取得に失敗しました');
+    }
+  });
 }


### PR DESCRIPTION
## Summary

- 日報作成画面 (SCR-003) の顧客選択ドロップダウンで使用する顧客一覧取得APIエンドポイントを追加
- `useCustomers` フックが呼び出す `/api/v1/customers?is_active=true` に対応

## 機能

- `is_active` パラメータ: 有効/無効でフィルタ
- `keyword` パラメータ: 顧客名・顧客コードで部分一致検索

## 背景

PR#77 (日報作成・編集画面) でコミットし忘れた顧客APIを追加。

## Test plan

- [ ] `npm run build` が成功すること
- [ ] `npm run lint` が成功すること
- [ ] 日報作成画面で顧客選択ドロップダウンが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)