### PR TITLE
feat: GET /api/v1/sales-persons を機能拡張 (#32)

### DIFF
--- a/src/app/api/v1/sales-persons/__tests__/route.test.ts
+++ b/src/app/api/v1/sales-persons/__tests__/route.test.ts
@@ -1,0 +1,624 @@
+/**
+ * GET /api/v1/sales-persons APIのテスト
+ *
+ * @vitest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { generateToken } from '@/lib/auth/jwt';
+import { prisma } from '@/lib/prisma';
+import type { JwtPayload } from '@/types';
+
+import { GET } from '../route';
+
+// Prisma モック
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    salesPerson: {
+      count: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const TEST_SECRET = 'test-secret-key-for-testing-only-32-chars';
+
+// モックデータ: 営業担当者
+const mockMember = {
+  id: 1,
+  employeeCode: 'EMP001',
+  name: 'テスト太郎',
+  email: 'member@example.com',
+  role: 'member' as const,
+  isActive: true,
+  createdAt: new Date('2025-01-01T00:00:00Z'),
+  manager: {
+    id: 3,
+    name: 'テスト課長',
+  },
+};
+
+const mockMember2 = {
+  id: 2,
+  employeeCode: 'EMP002',
+  name: 'テスト花子',
+  email: 'member2@example.com',
+  role: 'member' as const,
+  isActive: true,
+  createdAt: new Date('2025-01-02T00:00:00Z'),
+  manager: {
+    id: 3,
+    name: 'テスト課長',
+  },
+};
+
+const mockManager = {
+  id: 3,
+  employeeCode: 'EMP003',
+  name: 'テスト課長',
+  email: 'manager@example.com',
+  role: 'manager' as const,
+  isActive: true,
+  createdAt: new Date('2025-01-03T00:00:00Z'),
+  manager: null,
+};
+
+const mockAdmin = {
+  id: 4,
+  employeeCode: 'EMP004',
+  name: 'テスト管理者',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  isActive: true,
+  createdAt: new Date('2025-01-04T00:00:00Z'),
+  manager: null,
+};
+
+const mockInactiveMember = {
+  id: 5,
+  employeeCode: 'EMP005',
+  name: '退職済太郎',
+  email: 'inactive@example.com',
+  role: 'member' as const,
+  isActive: false,
+  createdAt: new Date('2025-01-05T00:00:00Z'),
+  manager: {
+    id: 3,
+    name: 'テスト課長',
+  },
+};
+
+const allSalesPersons = [mockMember, mockMember2, mockManager, mockAdmin, mockInactiveMember];
+
+/**
+ * テスト用のリクエストを作成
+ */
+function createRequest(token?: string, params?: Record<string, string | undefined>): NextRequest {
+  const url = new URL('http://localhost:3000/api/v1/sales-persons');
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) {
+        url.searchParams.set(key, value);
+      }
+    });
+  }
+
+  if (token) {
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('Authorization', `Bearer ${token}`);
+
+    return new NextRequest(url, {
+      method: 'GET',
+      headers,
+    });
+  }
+
+  return new NextRequest(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+describe('GET /api/v1/sales-persons', () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+  });
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('認証エラー', () => {
+    it('トークンなしの場合は401を返す', async () => {
+      const request = createRequest(); // トークンなし
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('認証が必要です');
+    });
+
+    it('無効なトークンの場合は401を返す', async () => {
+      const request = createRequest('invalid-token');
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+    });
+  });
+
+  describe('一覧取得（フィルタなし）', () => {
+    it('全営業担当者一覧を取得できる', async () => {
+      // モック設定
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      countMock.mockResolvedValueOnce(allSalesPersons.length);
+      findManyMock.mockResolvedValueOnce(allSalesPersons as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token);
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(allSalesPersons.length);
+      expect(data.pagination).toBeDefined();
+      expect(data.pagination.current_page).toBe(1);
+      expect(data.pagination.per_page).toBe(20);
+      expect(data.pagination.total_count).toBe(allSalesPersons.length);
+    });
+
+    it('レスポンス形式が正しい（manager がオブジェクト形式）', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      countMock.mockResolvedValueOnce(1);
+      findManyMock.mockResolvedValueOnce([mockMember] as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token);
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data[0]).toMatchObject({
+        id: mockMember.id,
+        employee_code: mockMember.employeeCode,
+        name: mockMember.name,
+        email: mockMember.email,
+        role: mockMember.role,
+        is_active: mockMember.isActive,
+        manager: {
+          id: mockMember.manager.id,
+          name: mockMember.manager.name,
+        },
+      });
+      // created_at がISO形式であることを確認
+      expect(data.data[0].created_at).toBe(mockMember.createdAt.toISOString());
+    });
+
+    it('上長がいない場合は manager が null', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      countMock.mockResolvedValueOnce(1);
+      findManyMock.mockResolvedValueOnce([mockManager] as never);
+
+      const payload: JwtPayload = {
+        userId: mockManager.id,
+        email: mockManager.email,
+        role: mockManager.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token);
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data[0].manager).toBeNull();
+    });
+  });
+
+  describe('is_active フィルタ', () => {
+    it('is_active=true で有効な営業担当者のみ取得', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      const activePersons = allSalesPersons.filter((p) => p.isActive);
+      countMock.mockResolvedValueOnce(activePersons.length);
+      findManyMock.mockResolvedValueOnce(activePersons as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { is_active: 'true' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(activePersons.length);
+
+      // count が正しい条件で呼ばれたことを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { isActive: true },
+      });
+    });
+
+    it('is_active=false で無効な営業担当者のみ取得', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      const inactivePersons = allSalesPersons.filter((p) => !p.isActive);
+      countMock.mockResolvedValueOnce(inactivePersons.length);
+      findManyMock.mockResolvedValueOnce(inactivePersons as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { is_active: 'false' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(inactivePersons.length);
+
+      // count が正しい条件で呼ばれたことを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { isActive: false },
+      });
+    });
+  });
+
+  describe('role フィルタ', () => {
+    it('role=member でメンバーのみ取得', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      const members = allSalesPersons.filter((p) => p.role === 'member');
+      countMock.mockResolvedValueOnce(members.length);
+      findManyMock.mockResolvedValueOnce(members as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { role: 'member' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(members.length);
+
+      // count が正しい条件で呼ばれたことを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { role: 'member' },
+      });
+    });
+
+    it('role=manager で上長のみ取得', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      const managers = allSalesPersons.filter((p) => p.role === 'manager');
+      countMock.mockResolvedValueOnce(managers.length);
+      findManyMock.mockResolvedValueOnce(managers as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { role: 'manager' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(managers.length);
+
+      // count が正しい条件で呼ばれたことを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { role: 'manager' },
+      });
+    });
+
+    it('role=admin で管理者のみ取得', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      const admins = allSalesPersons.filter((p) => p.role === 'admin');
+      countMock.mockResolvedValueOnce(admins.length);
+      findManyMock.mockResolvedValueOnce(admins as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { role: 'admin' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(admins.length);
+
+      // count が正しい条件で呼ばれたことを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { role: 'admin' },
+      });
+    });
+
+    it('不正な role の場合は422エラー', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { role: 'invalid_role' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('複合フィルタ', () => {
+    it('is_active=true かつ role=member でフィルタ', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      const filteredPersons = allSalesPersons.filter((p) => p.isActive && p.role === 'member');
+      countMock.mockResolvedValueOnce(filteredPersons.length);
+      findManyMock.mockResolvedValueOnce(filteredPersons as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { is_active: 'true', role: 'member' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveLength(filteredPersons.length);
+
+      // count が正しい条件で呼ばれたことを確認
+      expect(countMock).toHaveBeenCalledWith({
+        where: { isActive: true, role: 'member' },
+      });
+    });
+  });
+
+  describe('ページネーション', () => {
+    it('デフォルトのページネーション（page=1, per_page=20）', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      countMock.mockResolvedValueOnce(100);
+      findManyMock.mockResolvedValueOnce(allSalesPersons.slice(0, 5) as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token);
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.pagination.current_page).toBe(1);
+      expect(data.pagination.per_page).toBe(20);
+      expect(data.pagination.total_count).toBe(100);
+      expect(data.pagination.total_pages).toBe(5);
+
+      // findMany が正しいパラメータで呼ばれたことを確認
+      expect(findManyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 0,
+          take: 20,
+        })
+      );
+    });
+
+    it('page=2, per_page=10 でページネーション', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      const findManyMock = vi.mocked(prisma.salesPerson.findMany);
+
+      countMock.mockResolvedValueOnce(50);
+      findManyMock.mockResolvedValueOnce(allSalesPersons.slice(0, 5) as never);
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { page: '2', per_page: '10' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.pagination.current_page).toBe(2);
+      expect(data.pagination.per_page).toBe(10);
+      expect(data.pagination.total_count).toBe(50);
+      expect(data.pagination.total_pages).toBe(5);
+
+      // findMany が正しいパラメータで呼ばれたことを確認（offset = (2-1) * 10 = 10）
+      expect(findManyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 10,
+          take: 10,
+        })
+      );
+    });
+
+    it('per_page の最大値（100）を超える場合はエラー', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { per_page: '101' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toContain('100');
+    });
+
+    it('page が0以下の場合はエラー', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { page: '0' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('per_page が0以下の場合はエラー', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token, { per_page: '0' });
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    it('データベースエラーの場合は500を返す', async () => {
+      const countMock = vi.mocked(prisma.salesPerson.count);
+      countMock.mockRejectedValueOnce(new Error('Database connection error'));
+
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: mockMember.role,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+      const token = await generateToken(payload);
+      const request = createRequest(token);
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INTERNAL_ERROR');
+    });
+  });
+});

--- a/src/app/api/v1/sales-persons/route.ts
+++ b/src/app/api/v1/sales-persons/route.ts
@@ -6,35 +6,98 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 
-import { successResponse, errorResponse } from '@/lib/api/response';
+import {
+  paginatedResponse,
+  errorResponse,
+  calculatePagination,
+  calculateOffset,
+} from '@/lib/api/response';
 import { withAuth, type AuthUser } from '@/lib/auth/middleware';
 import { prisma } from '@/lib/prisma';
+import { salesPersonQuerySchema } from '@/lib/validations/sales-person';
 
 /**
  * GET /api/v1/sales-persons
  *
  * 営業担当者一覧を取得する。
  * 認証が必要。
+ *
+ * クエリパラメータ:
+ * - is_active: boolean - 有効/無効でフィルタ（省略時はフィルタなし）
+ * - role: string - 役職でフィルタ（member/manager/admin）
+ * - page: integer - ページ番号（デフォルト: 1）
+ * - per_page: integer - 1ページあたりの件数（デフォルト: 20、最大: 100）
  */
 export async function GET(request: NextRequest) {
-  return withAuth(request, async (_req, _user: AuthUser): Promise<NextResponse> => {
+  return withAuth(request, async (req, _user: AuthUser): Promise<NextResponse> => {
     try {
-      // is_activeなユーザーのみ取得
+      // クエリパラメータを取得
+      const searchParams = req.nextUrl.searchParams;
+      const queryParams = {
+        isActive: searchParams.get('is_active') || undefined,
+        role: searchParams.get('role') || undefined,
+        page: searchParams.get('page') || undefined,
+        perPage: searchParams.get('per_page') || undefined,
+      };
+
+      // バリデーション
+      const validationResult = salesPersonQuerySchema.safeParse(queryParams);
+      if (!validationResult.success) {
+        const issues = validationResult.error.issues;
+        const firstError = issues[0];
+        return errorResponse('VALIDATION_ERROR', firstError?.message || '入力値が不正です');
+      }
+
+      const { isActive, role, page, perPage } = validationResult.data;
+
+      // 検索条件を構築
+      const whereCondition: {
+        isActive?: boolean;
+        role?: 'member' | 'manager' | 'admin';
+      } = {};
+
+      // is_activeフィルタ（指定された場合のみ適用）
+      if (isActive !== undefined) {
+        whereCondition.isActive = isActive;
+      }
+
+      // roleフィルタ（指定された場合のみ適用）
+      if (role !== undefined) {
+        whereCondition.role = role;
+      }
+
+      // 総件数を取得
+      const totalCount = await prisma.salesPerson.count({
+        where: whereCondition,
+      });
+
+      // ページネーション計算
+      const pagination = calculatePagination(page, perPage, totalCount);
+      const offset = calculateOffset(page, perPage);
+
+      // 営業担当者一覧を取得（上長情報を含む）
       const salesPersons = await prisma.salesPerson.findMany({
-        where: {
-          isActive: true,
-        },
+        where: whereCondition,
         select: {
           id: true,
           employeeCode: true,
           name: true,
           email: true,
           role: true,
-          managerId: true,
+          isActive: true,
+          createdAt: true,
+          manager: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         orderBy: {
           name: 'asc',
         },
+        skip: offset,
+        take: perPage,
       });
 
       // レスポンス形式に変換
@@ -44,10 +107,17 @@ export async function GET(request: NextRequest) {
         name: person.name,
         email: person.email,
         role: person.role,
-        manager_id: person.managerId,
+        manager: person.manager
+          ? {
+              id: person.manager.id,
+              name: person.manager.name,
+            }
+          : null,
+        is_active: person.isActive,
+        created_at: person.createdAt.toISOString(),
       }));
 
-      return successResponse(data);
+      return paginatedResponse(data, pagination);
     } catch (error) {
       console.error('Sales persons fetch error:', error);
       return errorResponse('INTERNAL_ERROR', '営業担当者一覧の取得に失敗しました');


### PR DESCRIPTION
## Summary

- 営業担当者一覧取得APIにフィルタリングとページネーション機能を追加
- クエリパラメータでのフィルタリング（is_active, role）
- ページネーション（page, per_page）
- manager情報をオブジェクト形式で返却
- is_active, created_at をレスポンスに追加

## Changes

- `src/app/api/v1/sales-persons/route.ts`: GET関数を機能拡張
- `src/app/api/v1/sales-persons/__tests__/route.test.ts`: 18テストケースを追加

## API仕様

### クエリパラメータ
| パラメータ | 型 | 説明 |
|------------|-----|------|
| is_active | boolean | 有効/無効でフィルタ |
| role | string | 役職でフィルタ（member/manager/admin） |
| page | integer | ページ番号（デフォルト: 1） |
| per_page | integer | 1ページあたりの件数（デフォルト: 20、最大: 100） |

### レスポンス形式
```json
{
  "success": true,
  "data": [
    {
      "id": 1,
      "employee_code": "EMP001",
      "name": "山田太郎",
      "email": "yamada@example.com",
      "role": "member",
      "manager": { "id": 3, "name": "佐藤次郎" },
      "is_active": true,
      "created_at": "2025-01-01T00:00:00.000Z"
    }
  ],
  "pagination": {
    "current_page": 1,
    "per_page": 20,
    "total_pages": 5,
    "total_count": 100
  }
}
```

## Test plan

- [x] 認証済みユーザーで営業担当者一覧が取得できる
- [x] is_activeフィルタが動作する
- [x] roleフィルタが動作する
- [x] ページネーションが動作する
- [x] manager情報がオブジェクト形式で返却される
- [x] 18テストケース全てパス

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)