### PR TITLE
feat: PUT /api/v1/sales-persons/{id} を実装 (#35)

### DIFF
--- a/src/app/api/v1/sales-persons/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/sales-persons/[id]/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/v1/sales-persons/{id} APIのテスト
+ * GET/PUT /api/v1/sales-persons/{id} APIのテスト
  *
  * @vitest-environment node
  */
@@ -9,15 +9,23 @@ import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vite
 
 import { generateToken } from '@/lib/auth/jwt';
 import { prisma } from '@/lib/prisma';
+import { hashPassword } from '@/lib/utils/password';
 import type { JwtPayload } from '@/types';
 
-import { GET } from '../route';
+import { GET, PUT } from '../route';
+
+// hashPasswordモック
+vi.mock('@/lib/utils/password', () => ({
+  hashPassword: vi.fn().mockResolvedValue('hashed_password'),
+}));
 
 // Prisma モック
 vi.mock('@/lib/prisma', () => ({
   prisma: {
     salesPerson: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -425,6 +433,726 @@ describe('GET /api/v1/sales-persons/{id}', () => {
           },
         },
       });
+    });
+  });
+});
+
+/**
+ * テスト用のPUTリクエストを作成
+ */
+function createPutRequest(id: string, body: Record<string, unknown>, token?: string): NextRequest {
+  const url = new URL(`http://localhost:3000/api/v1/sales-persons/${id}`);
+
+  const headers = new Headers();
+  headers.set('Content-Type', 'application/json');
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return new NextRequest(url, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('PUT /api/v1/sales-persons/{id}', () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+  });
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+    // モックの呼び出し履歴と実装をリセット
+    vi.resetAllMocks();
+    // hashPasswordのデフォルト実装を再設定
+    vi.mocked(hashPassword).mockResolvedValue('hashed_password');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('認証・認可エラー', () => {
+    it('トークンなしの場合は401を返す', async () => {
+      const request = createPutRequest('1', { name: '更新名' });
+      const context = createContext('1');
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('無効なトークンの場合は401を返す', async () => {
+      const request = createPutRequest('1', { name: '更新名' }, 'invalid-token');
+      const context = createContext('1');
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('一般営業（member）の場合は403を返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockMember.id,
+        email: mockMember.email,
+        role: 'member',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { name: '更新名' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('FORBIDDEN');
+    });
+
+    it('上長（manager）の場合は403を返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockManager.id,
+        email: mockManager.email,
+        role: 'manager',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { name: '更新名' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('FORBIDDEN');
+    });
+  });
+
+  describe('バリデーションエラー', () => {
+    it('IDが数値でない場合は422を返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('abc', { name: '更新名' }, token);
+      const context = createContext('abc');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toBe('IDは正の整数で指定してください');
+    });
+
+    it('IDが0の場合は422を返す', async () => {
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('0', { name: '更新名' }, token);
+      const context = createContext('0');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('nameが空文字の場合は422を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { name: '' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('emailが無効な形式の場合は422を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { email: 'invalid-email' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('passwordが7文字以下の場合は422を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { password: '1234567' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('roleが無効な値の場合は422を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { role: 'invalid' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('NOT_FOUNDエラー', () => {
+    it('存在しないIDの場合は404を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      findUniqueMock.mockResolvedValueOnce(null);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('9999', { name: '更新名' }, token);
+      const context = createContext('9999');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('NOT_FOUND');
+      expect(data.error.message).toBe('営業担当者が見つかりません');
+    });
+  });
+
+  describe('重複エラー', () => {
+    it('メールアドレスが他のユーザーと重複する場合は409を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const findFirstMock = vi.mocked(prisma.salesPerson.findFirst);
+
+      // 対象の営業担当者が存在する
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      // メールアドレスが他のユーザーで使用されている
+      findFirstMock.mockResolvedValueOnce({ id: 2 } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { email: 'duplicate@example.com' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('DUPLICATE_EMAIL');
+      expect(data.error.message).toBe('このメールアドレスは既に使用されています');
+    });
+  });
+
+  describe('上長設定エラー', () => {
+    it('自分自身を上長に設定した場合は422を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { manager_id: 1 }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toBe('自分自身を上長に設定することはできません');
+    });
+
+    it('存在しない上長を指定した場合は422を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      // 対象の営業担当者が存在する
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      // 指定された上長が存在しない
+      findUniqueMock.mockResolvedValueOnce(null);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { manager_id: 9999 }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('VALIDATION_ERROR');
+      expect(data.error.message).toBe('指定された上長が存在しません');
+    });
+  });
+
+  describe('正常系', () => {
+    const updatedMember = {
+      id: 1,
+      employeeCode: 'EMP001',
+      name: '更新された名前',
+      email: 'updated@example.com',
+      role: 'manager' as const,
+      isActive: true,
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+      updatedAt: new Date('2025-01-15T00:00:00Z'),
+      manager: {
+        id: 3,
+        name: 'テスト課長',
+      },
+    };
+
+    it('名前のみ更新できる', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      updateMock.mockResolvedValueOnce({
+        ...updatedMember,
+        name: '新しい名前',
+      } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { name: '新しい名前' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.name).toBe('新しい名前');
+      // 名前のみが更新データに含まれることを確認
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 1 },
+          data: expect.objectContaining({ name: '新しい名前' }),
+        })
+      );
+    });
+
+    it('メールアドレスを更新できる（重複なし）', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const findFirstMock = vi.mocked(prisma.salesPerson.findFirst);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      findFirstMock.mockResolvedValueOnce(null); // 重複なし
+      updateMock.mockResolvedValueOnce({
+        ...updatedMember,
+        email: 'newemail@example.com',
+      } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { email: 'newemail@example.com' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.email).toBe('newemail@example.com');
+      expect(findFirstMock).toHaveBeenCalledWith({
+        where: {
+          email: 'newemail@example.com',
+          id: { not: 1 },
+        },
+        select: { id: true },
+      });
+    });
+
+    it('パスワードを更新できる', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      updateMock.mockResolvedValueOnce(updatedMember as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { password: 'newpassword123' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(hashPassword).toHaveBeenCalledWith('newpassword123');
+      // パスワードハッシュが更新データに含まれることを確認
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ passwordHash: 'hashed_password' }),
+        })
+      );
+    });
+
+    it('パスワードが空文字の場合は更新しない', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      // 存在確認用のモック
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      updateMock.mockResolvedValueOnce({
+        ...updatedMember,
+        name: '名前',
+      } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { name: '名前', password: '' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(hashPassword).not.toHaveBeenCalled();
+      // パスワードが空文字の場合、passwordHashは更新データに含まれない
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.not.objectContaining({ passwordHash: expect.anything() }),
+        })
+      );
+    });
+
+    it('roleを更新できる', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      updateMock.mockResolvedValueOnce({
+        id: 1,
+        employeeCode: 'EMP001',
+        name: '更新された名前',
+        email: 'updated@example.com',
+        role: 'admin' as const,
+        isActive: true,
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+        updatedAt: new Date('2025-01-15T00:00:00Z'),
+        manager: {
+          id: 3,
+          name: 'テスト課長',
+        },
+      } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { role: 'admin' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.role).toBe('admin');
+    });
+
+    it('上長を設定できる', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      // 対象の営業担当者が存在する
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      // 指定された上長が存在する
+      findUniqueMock.mockResolvedValueOnce({ id: 3 } as never);
+      updateMock.mockResolvedValueOnce(updatedMember as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { manager_id: 3 }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.manager.id).toBe(3);
+    });
+
+    it('上長をnullにできる（上長解除）', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      updateMock.mockResolvedValueOnce({
+        id: 1,
+        employeeCode: 'EMP001',
+        name: '更新された名前',
+        email: 'updated@example.com',
+        role: 'manager' as const,
+        isActive: true,
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+        updatedAt: new Date('2025-01-15T00:00:00Z'),
+        manager: null,
+      } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { manager_id: null }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.manager).toBeNull();
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ managerId: null }),
+        })
+      );
+    });
+
+    it('is_activeを更新できる（無効化）', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      updateMock.mockResolvedValueOnce({
+        id: 1,
+        employeeCode: 'EMP001',
+        name: '更新された名前',
+        email: 'updated@example.com',
+        role: 'manager' as const,
+        isActive: false,
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+        updatedAt: new Date('2025-01-15T00:00:00Z'),
+        manager: {
+          id: 3,
+          name: 'テスト課長',
+        },
+      } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { is_active: false }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.is_active).toBe(false);
+    });
+
+    it('複数項目を同時に更新できる', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const findFirstMock = vi.mocked(prisma.salesPerson.findFirst);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      findFirstMock.mockResolvedValueOnce(null); // メール重複なし
+      findUniqueMock.mockResolvedValueOnce({ id: 3 } as never); // 上長存在
+      updateMock.mockResolvedValueOnce({
+        id: 1,
+        employeeCode: 'EMP001',
+        name: '新しい名前',
+        email: 'newemail@example.com',
+        role: 'manager',
+        isActive: true,
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+        updatedAt: new Date('2025-01-15T00:00:00Z'),
+        manager: {
+          id: 3,
+          name: 'テスト課長',
+        },
+      } as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest(
+        '1',
+        {
+          name: '新しい名前',
+          email: 'newemail@example.com',
+          role: 'manager',
+          manager_id: 3,
+        },
+        token
+      );
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.name).toBe('新しい名前');
+      expect(data.data.email).toBe('newemail@example.com');
+      expect(data.data.role).toBe('manager');
+      expect(data.data.manager.id).toBe(3);
+    });
+
+    it('レスポンスがsnake_case形式で返される', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      const updateMock = vi.mocked(prisma.salesPerson.update);
+
+      findUniqueMock.mockResolvedValueOnce({ id: 1 } as never);
+      updateMock.mockResolvedValueOnce(updatedMember as never);
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { name: '更新名' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data).toHaveProperty('employee_code');
+      expect(data.data).toHaveProperty('is_active');
+      expect(data.data).toHaveProperty('created_at');
+      expect(data.data).toHaveProperty('updated_at');
+      expect(data.data).not.toHaveProperty('employeeCode');
+      expect(data.data).not.toHaveProperty('isActive');
+      expect(data.data).not.toHaveProperty('createdAt');
+      expect(data.data).not.toHaveProperty('updatedAt');
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    it('データベースエラーの場合は500を返す', async () => {
+      const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
+      findUniqueMock.mockRejectedValueOnce(new Error('Database connection error'));
+
+      const payload: JwtPayload = {
+        userId: mockAdmin.id,
+        email: mockAdmin.email,
+        role: 'admin',
+      };
+      const token = await generateToken(payload);
+      const request = createPutRequest('1', { name: '更新名' }, token);
+      const context = createContext('1');
+
+      const response = await PUT(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INTERNAL_ERROR');
+      expect(data.error.message).toBe('営業担当者の更新に失敗しました');
     });
   });
 });

--- a/src/app/api/v1/sales-persons/[id]/route.ts
+++ b/src/app/api/v1/sales-persons/[id]/route.ts
@@ -2,14 +2,17 @@
  * 営業担当者詳細API
  *
  * GET /api/v1/sales-persons/{id} - 営業担当者詳細を取得
+ * PUT /api/v1/sales-persons/{id} - 営業担当者情報を更新（管理者のみ）
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 
 import { successResponse, errorResponse } from '@/lib/api/response';
-import { withAuth, type AuthUser } from '@/lib/auth/middleware';
+import { withAuth, withAdmin, type AuthUser } from '@/lib/auth/middleware';
 import { prisma } from '@/lib/prisma';
+import { hashPassword } from '@/lib/utils/password';
 import { idParamSchema } from '@/lib/validations/common';
+import { updateSalesPersonSchema } from '@/lib/validations/sales-person';
 
 /**
  * GET /api/v1/sales-persons/{id}
@@ -108,6 +111,191 @@ export async function GET(
     } catch (error) {
       console.error('Sales person detail fetch error:', error);
       return errorResponse('INTERNAL_ERROR', '営業担当者の取得に失敗しました');
+    }
+  });
+}
+
+/**
+ * PUT /api/v1/sales-persons/{id}
+ *
+ * 営業担当者情報を更新する。
+ * 管理者のみ実行可能。
+ *
+ * パスパラメータ:
+ * - id: integer - 営業担当者ID
+ *
+ * リクエストボディ（snake_case）:
+ * - name: string - 氏名（任意）
+ * - email: string - メールアドレス（任意、一意）
+ * - password: string - パスワード（任意、省略時は変更しない）
+ * - role: string - 役職（member/manager/admin、任意）
+ * - manager_id: number | null - 上長ID（任意）
+ * - is_active: boolean - 有効フラグ（任意）
+ *
+ * レスポンス:
+ * - 200: 更新後の営業担当者情報
+ * - 401: 認証エラー
+ * - 403: 権限エラー（管理者以外）
+ * - 404: 営業担当者が存在しない
+ * - 409: メールアドレス重複
+ * - 422: バリデーションエラー
+ */
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  return withAdmin(request, async (_req, _user: AuthUser): Promise<NextResponse> => {
+    try {
+      // パスパラメータを取得
+      const params = await context.params;
+      const idParam = params.id;
+
+      // IDのバリデーション
+      const idValidationResult = idParamSchema.safeParse(idParam);
+      if (!idValidationResult.success) {
+        return errorResponse('VALIDATION_ERROR', 'IDは正の整数で指定してください');
+      }
+
+      const salesPersonId = idValidationResult.data;
+
+      // リクエストボディを取得
+      const body = await request.json();
+
+      // snake_case から camelCase に変換
+      const camelCaseBody = {
+        name: body.name,
+        email: body.email,
+        password: body.password,
+        role: body.role,
+        managerId: body.manager_id,
+        isActive: body.is_active,
+      };
+
+      // バリデーション
+      const validationResult = updateSalesPersonSchema.safeParse(camelCaseBody);
+      if (!validationResult.success) {
+        const issues = validationResult.error.issues;
+        const firstError = issues[0];
+        return errorResponse('VALIDATION_ERROR', firstError?.message || '入力値が不正です');
+      }
+
+      const { name, email, password, role, managerId, isActive } = validationResult.data;
+
+      // 営業担当者の存在確認
+      const existingSalesPerson = await prisma.salesPerson.findUnique({
+        where: { id: salesPersonId },
+        select: { id: true },
+      });
+
+      if (!existingSalesPerson) {
+        return errorResponse('NOT_FOUND', '営業担当者が見つかりません');
+      }
+
+      // メールアドレスの重複チェック（自分自身を除く）
+      if (email !== undefined) {
+        const existingEmail = await prisma.salesPerson.findFirst({
+          where: {
+            email,
+            id: { not: salesPersonId },
+          },
+          select: { id: true },
+        });
+
+        if (existingEmail) {
+          return errorResponse('DUPLICATE_EMAIL', 'このメールアドレスは既に使用されています');
+        }
+      }
+
+      // manager_idが指定されている場合、存在確認
+      if (managerId !== null && managerId !== undefined) {
+        // 自分自身を上長に設定できない
+        if (managerId === salesPersonId) {
+          return errorResponse('VALIDATION_ERROR', '自分自身を上長に設定することはできません');
+        }
+
+        const manager = await prisma.salesPerson.findUnique({
+          where: { id: managerId },
+          select: { id: true },
+        });
+
+        if (!manager) {
+          return errorResponse('VALIDATION_ERROR', '指定された上長が存在しません');
+        }
+      }
+
+      // 更新データを構築
+      const updateData: {
+        name?: string;
+        email?: string;
+        passwordHash?: string;
+        role?: 'member' | 'manager' | 'admin';
+        managerId?: number | null;
+        isActive?: boolean;
+      } = {};
+
+      if (name !== undefined) {
+        updateData.name = name;
+      }
+      if (email !== undefined) {
+        updateData.email = email;
+      }
+      if (password !== undefined && password !== '') {
+        updateData.passwordHash = await hashPassword(password);
+      }
+      if (role !== undefined) {
+        updateData.role = role;
+      }
+      if (managerId !== undefined) {
+        updateData.managerId = managerId;
+      }
+      if (isActive !== undefined) {
+        updateData.isActive = isActive;
+      }
+
+      // 営業担当者を更新
+      const salesPerson = await prisma.salesPerson.update({
+        where: { id: salesPersonId },
+        data: updateData,
+        select: {
+          id: true,
+          employeeCode: true,
+          name: true,
+          email: true,
+          role: true,
+          isActive: true,
+          createdAt: true,
+          updatedAt: true,
+          manager: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      });
+
+      // レスポンス形式に変換（snake_case）
+      const responseData = {
+        id: salesPerson.id,
+        employee_code: salesPerson.employeeCode,
+        name: salesPerson.name,
+        email: salesPerson.email,
+        role: salesPerson.role,
+        manager: salesPerson.manager
+          ? {
+              id: salesPerson.manager.id,
+              name: salesPerson.manager.name,
+            }
+          : null,
+        is_active: salesPerson.isActive,
+        created_at: salesPerson.createdAt.toISOString(),
+        updated_at: salesPerson.updatedAt.toISOString(),
+      };
+
+      return successResponse(responseData);
+    } catch (error) {
+      console.error('Sales person update error:', error);
+      return errorResponse('INTERNAL_ERROR', '営業担当者の更新に失敗しました');
     }
   });
 }

--- a/src/lib/validations/sales-person.ts
+++ b/src/lib/validations/sales-person.ts
@@ -34,12 +34,20 @@ export const createSalesPersonSchema = z.object({
 });
 
 // 営業担当者更新リクエストのスキーマ
-export const updateSalesPersonSchema = createSalesPersonSchema
-  .partial()
-  .omit({ employeeCode: true })
-  .extend({
-    password: passwordSchema.optional().or(z.literal('')),
-  });
+// partial() を使わず、明示的にすべてのフィールドをoptionalに定義
+// これにより default() の影響を受けず、undefinedのまま保持できる
+export const updateSalesPersonSchema = z.object({
+  name: z
+    .string()
+    .min(1, '氏名を入力してください')
+    .max(100, '氏名は100文字以内で入力してください')
+    .optional(),
+  email: emailSchema.optional(),
+  password: passwordSchema.optional().or(z.literal('')),
+  role: roleSchema.optional(),
+  managerId: z.number().int().positive().nullable().optional(),
+  isActive: z.boolean().optional(),
+});
 
 // 営業担当者検索クエリのスキーマ
 export const salesPersonQuerySchema = z


### PR DESCRIPTION
## Summary
- 営業担当者更新API (PUT /api/v1/sales-persons/{id}) を実装
- 管理者のみアクセス可能（withAdmin ミドルウェア使用）
- 25件のテストケースを追加

## 変更内容
- `src/app/api/v1/sales-persons/[id]/route.ts`: PUT メソッド追加
- `src/lib/validations/sales-person.ts`: updateSalesPersonSchema 改善
- テストファイル: 認証、認可、バリデーション、正常系、エラーハンドリングのテスト追加

## API仕様
- **エンドポイント**: PUT /api/v1/sales-persons/{id}
- **権限**: 管理者のみ
- **更新可能フィールド**: name, email, password, role, manager_id, is_active
- **更新不可**: employee_code
- **エラー**: 401 (認証), 403 (権限), 404 (NOT_FOUND), 409 (DUPLICATE_EMAIL), 422 (VALIDATION_ERROR)

## Test plan
- [x] 認証エラーテスト（トークンなし、無効なトークン）
- [x] 認可エラーテスト（一般営業、上長がアクセス）
- [x] バリデーションエラーテスト（無効なID形式、無効なメール形式など）
- [x] NOT_FOUNDテスト（存在しないID）
- [x] 重複エラーテスト（メールアドレス重複）
- [x] 上長設定エラーテスト（存在しない上長ID、自分自身を上長に設定）
- [x] 正常系テスト（全フィールド更新、部分更新、パスワード更新）
- [x] ビルド成功確認
- [x] 全586テストパス

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)