### PR TITLE
feat: GET /api/v1/customers を実装 (#39)

### DIFF
--- a/src/app/api/v1/customers/__tests__/route.test.ts
+++ b/src/app/api/v1/customers/__tests__/route.test.ts
@@ -504,7 +504,10 @@ describe('GET /api/v1/customers', () => {
       expect(countMock).toHaveBeenCalledWith({
         where: {
           isActive: true,
-          OR: [{ name: { contains: '株式会社ABC' } }, { customerCode: { contains: '株式会社ABC' } }],
+          OR: [
+            { name: { contains: '株式会社ABC' } },
+            { customerCode: { contains: '株式会社ABC' } },
+          ],
         },
       });
     });

--- a/src/app/api/v1/customers/route.ts
+++ b/src/app/api/v1/customers/route.ts
@@ -103,23 +103,25 @@ export async function GET(request: NextRequest) {
       });
 
       // レスポンス形式に変換（snake_case）
-      const data = customers.map((customer: {
-        id: number;
-        customerCode: string;
-        name: string;
-        address: string | null;
-        phone: string | null;
-        isActive: boolean;
-        createdAt: Date;
-      }) => ({
-        id: customer.id,
-        customer_code: customer.customerCode,
-        name: customer.name,
-        address: customer.address,
-        phone: customer.phone,
-        is_active: customer.isActive,
-        created_at: customer.createdAt.toISOString(),
-      }));
+      const data = customers.map(
+        (customer: {
+          id: number;
+          customerCode: string;
+          name: string;
+          address: string | null;
+          phone: string | null;
+          isActive: boolean;
+          createdAt: Date;
+        }) => ({
+          id: customer.id,
+          customer_code: customer.customerCode,
+          name: customer.name,
+          address: customer.address,
+          phone: customer.phone,
+          is_active: customer.isActive,
+          created_at: customer.createdAt.toISOString(),
+        })
+      );
 
       return paginatedResponse(data, pagination);
     } catch (error) {

--- a/src/lib/validations/customer.ts
+++ b/src/lib/validations/customer.ts
@@ -38,10 +38,7 @@ export const updateCustomerSchema = createCustomerSchema.partial().omit({ custom
 // 顧客検索クエリのスキーマ
 export const customerQuerySchema = z
   .object({
-    keyword: z
-      .string()
-      .max(200, 'キーワードは200文字以内で入力してください')
-      .optional(),
+    keyword: z.string().max(200, 'キーワードは200文字以内で入力してください').optional(),
     isActive: z
       .string()
       .transform((val) => {


### PR DESCRIPTION
## Summary
- 顧客一覧取得API (GET /api/v1/customers) を実装
- 認証済みユーザーのみアクセス可能（withAuth ミドルウェア使用）
- 30件のテストケースを追加

## 変更内容
- `src/app/api/v1/customers/route.ts`: GET メソッド実装
- `src/lib/validations/customer.ts`: customerQuerySchema にキーワード最大長制限追加
- テストファイル: 認証、バリデーション、検索、フィルタ、ページネーション、エラーハンドリングのテスト追加

## API仕様
- **エンドポイント**: GET /api/v1/customers
- **権限**: 認証済みユーザー（member, manager, admin）
- **クエリパラメータ**:
  - `keyword`: 顧客名・顧客コードで部分一致検索（OR条件）
  - `is_active`: 有効/無効でフィルタ
  - `page`: ページ番号（デフォルト: 1）
  - `per_page`: 1ページあたりの件数（デフォルト: 20、最大: 100）
- **エラー**: 401 (認証), 422 (VALIDATION_ERROR)

## Test plan
- [x] 認証エラーテスト（トークンなし、無効なトークン）
- [x] 一覧取得テスト（フィルタなし、レスポンス形式確認）
- [x] is_activeフィルタテスト（true/false/未指定）
- [x] キーワード検索テスト（顧客名、顧客コード、一致なし）
- [x] 複合フィルタテスト（is_active + keyword）
- [x] ページネーションテスト（デフォルト値、カスタム値、境界値）
- [x] バリデーションエラーテスト（キーワード最大長超過）
- [x] エラーハンドリングテスト（DBエラー）
- [x] ソート順テスト（顧客コード昇順）
- [x] 認可テスト（member/manager/adminロール）
- [x] ビルド成功確認
- [x] 全630テストパス

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)