### PR TITLE
feat: 顧客マスタ画面 (SCR-006) を実装

### DIFF
--- a/src/app/admin/customers/page.tsx
+++ b/src/app/admin/customers/page.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import { CustomerTable, CustomerFormModal, CustomerSearchForm } from '@/components/admin/customers';
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { ErrorMessage } from '@/components/common/ErrorMessage';
+import { LoadingPage } from '@/components/common/Loading';
+import { PageContainer } from '@/components/layout/PageContainer';
+import { Button } from '@/components/ui/button';
+import { useRequireRole } from '@/hooks/useAuth';
+import { useCustomersAdmin } from '@/hooks/useCustomersAdmin';
+import type { Customer, CustomerFormData } from '@/types/customer';
+
+/**
+ * 顧客マスタ画面（SCR-006）
+ *
+ * 顧客の一覧表示、登録、編集、削除を行う管理画面。
+ * 管理者のみアクセス可能。
+ */
+export default function CustomersAdminPage() {
+  // 管理者権限のみアクセス可能
+  const auth = useRequireRole(['admin']);
+
+  const {
+    customers,
+    pagination,
+    isLoading,
+    error,
+    fetchCustomers,
+    createCustomer,
+    updateCustomer,
+    deleteCustomer,
+  } = useCustomersAdmin();
+
+  // モーダルの状態
+  const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 検索条件
+  const [keyword, setKeyword] = useState('');
+  const [currentKeyword, setCurrentKeyword] = useState('');
+
+  // 初回読み込みフラグ
+  const isInitializedRef = useRef(false);
+
+  // 現在のページ
+  const [currentPage, setCurrentPage] = useState(1);
+
+  /**
+   * データを取得
+   */
+  const loadData = useCallback(
+    async (page: number = 1, searchKeyword: string = '') => {
+      await fetchCustomers({ page, per_page: 20, keyword: searchKeyword || undefined });
+      setCurrentPage(page);
+    },
+    [fetchCustomers]
+  );
+
+  // 認証完了後に初回データ取得
+  useEffect(() => {
+    if (!auth.isLoading && auth.isAuthenticated && !isInitializedRef.current) {
+      isInitializedRef.current = true;
+      loadData(1, '');
+    }
+  }, [auth.isLoading, auth.isAuthenticated, loadData]);
+
+  /**
+   * 検索実行
+   */
+  const handleSearch = (searchKeyword: string) => {
+    setCurrentKeyword(searchKeyword);
+    loadData(1, searchKeyword);
+  };
+
+  /**
+   * 新規登録ボタンクリック
+   */
+  const handleCreateClick = () => {
+    setSelectedCustomer(null);
+    setIsFormModalOpen(true);
+  };
+
+  /**
+   * 編集ボタンクリック
+   */
+  const handleEditClick = (customer: Customer) => {
+    setSelectedCustomer(customer);
+    setIsFormModalOpen(true);
+  };
+
+  /**
+   * 削除ボタンクリック
+   */
+  const handleDeleteClick = (customer: Customer) => {
+    setSelectedCustomer(customer);
+    setIsDeleteDialogOpen(true);
+  };
+
+  /**
+   * フォーム送信
+   */
+  const handleFormSubmit = async (data: CustomerFormData) => {
+    setIsSubmitting(true);
+
+    try {
+      if (selectedCustomer) {
+        // 更新
+        const result = await updateCustomer(selectedCustomer.id, {
+          name: data.name,
+          address: data.address || null,
+          phone: data.phone || null,
+          is_active: data.isActive,
+        });
+
+        if (result.success) {
+          toast.success('顧客を更新しました');
+          setIsFormModalOpen(false);
+          await loadData(currentPage, currentKeyword);
+        } else {
+          toast.error(result.error || '更新に失敗しました');
+        }
+      } else {
+        // 新規登録
+        const result = await createCustomer({
+          customer_code: data.customerCode,
+          name: data.name,
+          address: data.address || null,
+          phone: data.phone || null,
+          is_active: data.isActive,
+        });
+
+        if (result.success) {
+          toast.success('顧客を登録しました');
+          setIsFormModalOpen(false);
+          await loadData(1, currentKeyword);
+        } else {
+          toast.error(result.error || '登録に失敗しました');
+        }
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * 削除実行
+   */
+  const handleDeleteConfirm = async () => {
+    if (!selectedCustomer) return;
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await deleteCustomer(selectedCustomer.id);
+
+      if (result.success) {
+        toast.success('顧客を削除しました');
+        setIsDeleteDialogOpen(false);
+        await loadData(currentPage, currentKeyword);
+      } else {
+        toast.error(result.error || '削除に失敗しました');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * ページ変更
+   */
+  const handlePageChange = (page: number) => {
+    loadData(page, currentKeyword);
+  };
+
+  // 認証ローディング中
+  if (auth.isLoading) {
+    return <LoadingPage />;
+  }
+
+  // 未認証または権限なし（リダイレクト処理中）
+  if (!auth.isAuthenticated || auth.user?.role !== 'admin') {
+    return <LoadingPage />;
+  }
+
+  return (
+    <PageContainer
+      title="顧客マスタ管理"
+      breadcrumbs={[{ label: '顧客マスタ管理' }]}
+      actions={
+        <Button onClick={handleCreateClick}>
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          新規登録
+        </Button>
+      }
+    >
+      {/* 検索フォーム */}
+      <CustomerSearchForm
+        keyword={keyword}
+        onKeywordChange={setKeyword}
+        onSearch={handleSearch}
+        isLoading={isLoading}
+      />
+
+      {/* エラーメッセージ */}
+      {error && (
+        <div className="mb-6">
+          <ErrorMessage message={error} />
+        </div>
+      )}
+
+      {/* 顧客一覧 */}
+      <CustomerTable
+        customers={customers}
+        pagination={pagination}
+        isLoading={isLoading}
+        onPageChange={handlePageChange}
+        onEdit={handleEditClick}
+        onDelete={handleDeleteClick}
+      />
+
+      {/* 登録・編集モーダル */}
+      <CustomerFormModal
+        open={isFormModalOpen}
+        onOpenChange={setIsFormModalOpen}
+        onSubmit={handleFormSubmit}
+        customer={selectedCustomer}
+        isLoading={isSubmitting}
+      />
+
+      {/* 削除確認ダイアログ */}
+      <ConfirmDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title="顧客の削除"
+        description={
+          selectedCustomer
+            ? `「${selectedCustomer.name}」を削除しますか？この操作により、顧客は無効化されます。`
+            : ''
+        }
+        confirmLabel="削除"
+        cancelLabel="キャンセル"
+        onConfirm={handleDeleteConfirm}
+        isLoading={isSubmitting}
+        variant="destructive"
+      />
+    </PageContainer>
+  );
+}

--- a/src/components/admin/customers/CustomerFormModal.tsx
+++ b/src/components/admin/customers/CustomerFormModal.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { LoadingSpinner } from '@/components/common/Loading';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import type { Customer, CustomerFormData } from '@/types/customer';
+
+// 電話番号の正規表現（日本の電話番号形式）
+const phoneRegex = /^(0\d{1,4}-?\d{1,4}-?\d{3,4})?$/;
+
+// フォームのバリデーションスキーマ
+const createFormSchema = (isEditMode: boolean) =>
+  z.object({
+    customerCode: isEditMode
+      ? z.string()
+      : z
+          .string()
+          .min(1, '顧客コードを入力してください')
+          .max(20, '顧客コードは20文字以内で入力してください')
+          .regex(/^[a-zA-Z0-9]+$/, '顧客コードは半角英数字で入力してください'),
+    name: z
+      .string()
+      .min(1, '顧客名を入力してください')
+      .max(200, '顧客名は200文字以内で入力してください'),
+    address: z
+      .string()
+      .max(500, '住所は500文字以内で入力してください')
+      .optional()
+      .or(z.literal('')),
+    phone: z
+      .string()
+      .refine((val) => !val || phoneRegex.test(val), {
+        message: '電話番号の形式が正しくありません（例: 03-1234-5678）',
+      })
+      .optional()
+      .or(z.literal('')),
+    isActive: z.boolean(),
+  });
+
+type FormSchema = z.infer<ReturnType<typeof createFormSchema>>;
+
+interface CustomerFormModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: CustomerFormData) => Promise<void>;
+  customer?: Customer | null;
+  isLoading?: boolean;
+}
+
+/**
+ * 顧客登録・編集モーダル
+ */
+export function CustomerFormModal({
+  open,
+  onOpenChange,
+  onSubmit,
+  customer,
+  isLoading = false,
+}: CustomerFormModalProps) {
+  const isEditMode = !!customer;
+  const formSchema = createFormSchema(isEditMode);
+
+  const form = useForm<FormSchema>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      customerCode: '',
+      name: '',
+      address: '',
+      phone: '',
+      isActive: true,
+    },
+  });
+
+  // 編集時にフォームに値をセット
+  useEffect(() => {
+    if (open) {
+      if (customer) {
+        form.reset({
+          customerCode: customer.customer_code,
+          name: customer.name,
+          address: customer.address || '',
+          phone: customer.phone || '',
+          isActive: customer.is_active,
+        });
+      } else {
+        form.reset({
+          customerCode: '',
+          name: '',
+          address: '',
+          phone: '',
+          isActive: true,
+        });
+      }
+    }
+  }, [open, customer, form]);
+
+  const handleSubmit = async (data: FormSchema) => {
+    await onSubmit({
+      customerCode: data.customerCode,
+      name: data.name,
+      address: data.address || '',
+      phone: data.phone || '',
+      isActive: data.isActive,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEditMode ? '顧客 編集' : '顧客 登録'}</DialogTitle>
+          <DialogDescription>
+            {isEditMode ? '顧客の情報を編集します。' : '新しい顧客を登録します。'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="customerCode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>顧客コード *</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="C001" disabled={isEditMode || isLoading} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>顧客名 *</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="株式会社ABC" disabled={isLoading} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>住所</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder="東京都港区..."
+                      disabled={isLoading}
+                      rows={2}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>電話番号</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="03-1234-5678" disabled={isLoading} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isActive"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>状態 *</FormLabel>
+                  <div className="flex items-center gap-4">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="isActive"
+                        checked={field.value === true}
+                        onChange={() => field.onChange(true)}
+                        disabled={isLoading}
+                        className="h-4 w-4"
+                      />
+                      <span>有効</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="isActive"
+                        checked={field.value === false}
+                        onChange={() => field.onChange(false)}
+                        disabled={isLoading}
+                        className="h-4 w-4"
+                      />
+                      <span>無効</span>
+                    </label>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isLoading}
+              >
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading && <LoadingSpinner className="mr-2" />}
+                保存
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/customers/CustomerSearchForm.tsx
+++ b/src/components/admin/customers/CustomerSearchForm.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { SearchInput } from '@/components/form/SearchInput';
+
+interface CustomerSearchFormProps {
+  keyword: string;
+  onKeywordChange: (keyword: string) => void;
+  onSearch: (keyword: string) => void;
+  isLoading?: boolean;
+}
+
+/**
+ * 顧客検索フォーム
+ */
+export function CustomerSearchForm({
+  keyword,
+  onKeywordChange,
+  onSearch,
+  isLoading = false,
+}: CustomerSearchFormProps) {
+  return (
+    <div className="mb-6 rounded-lg border bg-card p-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+        <div className="flex-1">
+          <label htmlFor="customer-search" className="mb-2 block text-sm font-medium">
+            検索
+          </label>
+          <SearchInput
+            id="customer-search"
+            value={keyword}
+            onChange={onKeywordChange}
+            onSearch={onSearch}
+            placeholder="顧客名・顧客コードで検索..."
+            showSearchButton
+            disabled={isLoading}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/customers/CustomerTable.tsx
+++ b/src/components/admin/customers/CustomerTable.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Edit, Trash2 } from 'lucide-react';
+
+import { DataTable, type Column } from '@/components/data/DataTable';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { Customer } from '@/types/customer';
+
+interface CustomerTableProps {
+  customers: Customer[];
+  pagination?: {
+    currentPage: number;
+    perPage: number;
+    totalPages: number;
+    totalCount: number;
+  } | null;
+  isLoading?: boolean;
+  onPageChange?: (page: number) => void;
+  onEdit: (customer: Customer) => void;
+  onDelete: (customer: Customer) => void;
+}
+
+/**
+ * 顧客一覧テーブル
+ */
+export function CustomerTable({
+  customers,
+  pagination,
+  isLoading,
+  onPageChange,
+  onEdit,
+  onDelete,
+}: CustomerTableProps) {
+  const columns: Column<Customer>[] = [
+    {
+      key: 'customer_code',
+      header: '顧客コード',
+      className: 'w-[120px]',
+    },
+    {
+      key: 'name',
+      header: '顧客名',
+      className: 'min-w-[200px]',
+    },
+    {
+      key: 'phone',
+      header: '電話番号',
+      className: 'min-w-[140px]',
+      render: (item) => item.phone || '-',
+    },
+    {
+      key: 'is_active',
+      header: '状態',
+      className: 'w-[80px]',
+      render: (item) => (
+        <Badge variant={item.is_active ? 'default' : 'destructive'}>
+          {item.is_active ? '有効' : '無効'}
+        </Badge>
+      ),
+    },
+    {
+      key: 'actions',
+      header: '操作',
+      className: 'w-[120px]',
+      render: (item) => (
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit(item);
+            }}
+            aria-label={`${item.name}を編集`}
+          >
+            <Edit className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(item);
+            }}
+            disabled={!item.is_active}
+            aria-label={`${item.name}を削除`}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={columns}
+      data={customers}
+      keyExtractor={(item) => item.id}
+      isLoading={isLoading}
+      emptyMessage="顧客が見つかりませんでした"
+      pagination={
+        pagination
+          ? {
+              ...pagination,
+              onPageChange: onPageChange || (() => {}),
+            }
+          : undefined
+      }
+    />
+  );
+}

--- a/src/components/admin/customers/index.ts
+++ b/src/components/admin/customers/index.ts
@@ -1,0 +1,3 @@
+export { CustomerTable } from './CustomerTable';
+export { CustomerFormModal } from './CustomerFormModal';
+export { CustomerSearchForm } from './CustomerSearchForm';

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -1,1 +1,2 @@
+export * from './customers';
 export * from './sales-persons';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useAuth, useRequireAuth, useRequireRole } from './useAuth';
 export { useCustomers, type CustomerItem } from './useCustomers';
+export { useCustomersAdmin } from './useCustomersAdmin';
 export {
   useReportList,
   useReportDetail,

--- a/src/hooks/useCustomersAdmin.ts
+++ b/src/hooks/useCustomersAdmin.ts
@@ -1,0 +1,197 @@
+/**
+ * 顧客管理用カスタムフック
+ *
+ * 顧客マスタ画面でのCRUD操作を提供する
+ */
+
+import { useCallback, useState } from 'react';
+
+import type { Pagination } from '@/types/api';
+import type { Customer, CreateCustomerRequest, UpdateCustomerRequest } from '@/types/customer';
+
+interface FetchCustomersParams {
+  page?: number;
+  per_page?: number;
+  is_active?: boolean;
+  keyword?: string;
+}
+
+interface UseCustomersAdminResult {
+  customers: Customer[];
+  pagination: {
+    currentPage: number;
+    perPage: number;
+    totalPages: number;
+    totalCount: number;
+  } | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchCustomers: (params?: FetchCustomersParams) => Promise<void>;
+  createCustomer: (data: CreateCustomerRequest) => Promise<{ success: boolean; error?: string }>;
+  updateCustomer: (
+    id: number,
+    data: UpdateCustomerRequest
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteCustomer: (id: number) => Promise<{ success: boolean; error?: string }>;
+}
+
+/**
+ * 顧客管理用カスタムフック
+ */
+export function useCustomersAdmin(): UseCustomersAdminResult {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [pagination, setPagination] = useState<{
+    currentPage: number;
+    perPage: number;
+    totalPages: number;
+    totalCount: number;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * 顧客一覧を取得
+   */
+  const fetchCustomers = useCallback(async (params?: FetchCustomersParams) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const searchParams = new URLSearchParams();
+      if (params?.page) searchParams.append('page', params.page.toString());
+      if (params?.per_page) searchParams.append('per_page', params.per_page.toString());
+      if (params?.is_active !== undefined)
+        searchParams.append('is_active', params.is_active.toString());
+      if (params?.keyword) searchParams.append('keyword', params.keyword);
+
+      const queryString = searchParams.toString();
+      const url = `/api/v1/customers${queryString ? `?${queryString}` : ''}`;
+
+      const response = await fetch(url, {
+        credentials: 'include',
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        setCustomers(result.data);
+        if (result.pagination) {
+          const paginationData = result.pagination as Pagination;
+          setPagination({
+            currentPage: paginationData.current_page,
+            perPage: paginationData.per_page,
+            totalPages: paginationData.total_pages,
+            totalCount: paginationData.total_count,
+          });
+        }
+      } else {
+        setError(result.error?.message || '顧客一覧の取得に失敗しました');
+      }
+    } catch (err) {
+      console.error('Failed to fetch customers:', err);
+      setError('顧客一覧の取得に失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  /**
+   * 顧客を新規作成
+   */
+  const createCustomer = useCallback(
+    async (data: CreateCustomerRequest): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const response = await fetch('/api/v1/customers', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify(data),
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          return { success: true };
+        } else {
+          return { success: false, error: result.error?.message || '登録に失敗しました' };
+        }
+      } catch (err) {
+        console.error('Failed to create customer:', err);
+        return { success: false, error: '登録に失敗しました' };
+      }
+    },
+    []
+  );
+
+  /**
+   * 顧客を更新
+   */
+  const updateCustomer = useCallback(
+    async (
+      id: number,
+      data: UpdateCustomerRequest
+    ): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const response = await fetch(`/api/v1/customers/${id}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify(data),
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          return { success: true };
+        } else {
+          return { success: false, error: result.error?.message || '更新に失敗しました' };
+        }
+      } catch (err) {
+        console.error('Failed to update customer:', err);
+        return { success: false, error: '更新に失敗しました' };
+      }
+    },
+    []
+  );
+
+  /**
+   * 顧客を削除（論理削除）
+   */
+  const deleteCustomer = useCallback(
+    async (id: number): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const response = await fetch(`/api/v1/customers/${id}`, {
+          method: 'DELETE',
+          credentials: 'include',
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          return { success: true };
+        } else {
+          return { success: false, error: result.error?.message || '削除に失敗しました' };
+        }
+      } catch (err) {
+        console.error('Failed to delete customer:', err);
+        return { success: false, error: '削除に失敗しました' };
+      }
+    },
+    []
+  );
+
+  return {
+    customers,
+    pagination,
+    isLoading,
+    error,
+    fetchCustomers,
+    createCustomer,
+    updateCustomer,
+    deleteCustomer,
+  };
+}

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -1,0 +1,55 @@
+/**
+ * 顧客関連の型定義
+ */
+
+/**
+ * 顧客（一覧表示用）
+ */
+export interface Customer {
+  id: number;
+  customer_code: string;
+  name: string;
+  address: string | null;
+  phone: string | null;
+  is_active: boolean;
+  created_at: string;
+}
+
+/**
+ * 顧客詳細
+ */
+export interface CustomerDetail extends Customer {
+  updated_at: string;
+}
+
+/**
+ * 顧客作成リクエスト
+ */
+export interface CreateCustomerRequest {
+  customer_code: string;
+  name: string;
+  address?: string | null;
+  phone?: string | null;
+  is_active: boolean;
+}
+
+/**
+ * 顧客更新リクエスト
+ */
+export interface UpdateCustomerRequest {
+  name?: string;
+  address?: string | null;
+  phone?: string | null;
+  is_active?: boolean;
+}
+
+/**
+ * 顧客フォームデータ
+ */
+export interface CustomerFormData {
+  customerCode: string;
+  name: string;
+  address: string;
+  phone: string;
+  isActive: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './auth';
+export * from './customer';
 export * from './sales-person';


### PR DESCRIPTION
## 概要
Issue #44 の実装。顧客マスタ管理画面を追加。

## 変更内容
- `/admin/customers` ページを追加（管理者のみアクセス可能）
- 顧客一覧表示（ページネーション付き）
- キーワード検索機能
- 新規登録・編集モーダル
- 削除確認ダイアログ（論理削除）

## 追加ファイル
### ページ
- `src/app/admin/customers/page.tsx`

### コンポーネント
- `src/components/admin/customers/CustomerTable.tsx`
- `src/components/admin/customers/CustomerFormModal.tsx`
- `src/components/admin/customers/CustomerSearchForm.tsx`
- `src/components/admin/customers/index.ts`

### フック
- `src/hooks/useCustomersAdmin.ts`

### 型定義
- `src/types/customer.ts`

## 機能
- 一覧表示（顧客コード、顧客名、電話番号、状態）
- キーワード検索（顧客名・顧客コードで検索）
- 新規登録（顧客コード、顧客名、住所、電話番号、状態）
- 編集（顧客コードは編集不可）
- 削除（論理削除: is_active=false）
- 権限チェック（管理者のみアクセス可能）

## 検証結果
- Lint: パス
- Build: 成功

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)