### PR TITLE
test: 結合テスト - マスタAPI (IT-030, IT-040)

### DIFF
--- a/src/app/api/v1/customers/__tests__/route.test.ts
+++ b/src/app/api/v1/customers/__tests__/route.test.ts
@@ -919,7 +919,7 @@ describe('POST /api/v1/customers', () => {
   });
 
   describe('認可エラー', () => {
-    it('memberロールでは403を返す', async () => {
+    it('[IT-040-02] memberロール（一般営業）では403を返す', async () => {
       const payload: JwtPayload = {
         userId: 1,
         email: 'member@example.com',
@@ -1175,7 +1175,7 @@ describe('POST /api/v1/customers', () => {
   });
 
   describe('顧客コード重複エラー', () => {
-    it('顧客コードが既に使用されている場合は409を返す', async () => {
+    it('[IT-040-03] 顧客コードが既に使用されている場合は409を返す', async () => {
       const findUniqueMock = vi.mocked(prisma.customer.findUnique);
       findUniqueMock.mockResolvedValueOnce({
         id: 1,
@@ -1210,7 +1210,7 @@ describe('POST /api/v1/customers', () => {
   });
 
   describe('正常系', () => {
-    it('全項目を指定して顧客を登録できる', async () => {
+    it('[IT-040-01] 管理者が全項目を指定して顧客を正常に登録できる', async () => {
       const findUniqueMock = vi.mocked(prisma.customer.findUnique);
       const createMock = vi.mocked(prisma.customer.create);
 

--- a/src/app/api/v1/sales-persons/__tests__/route.test.ts
+++ b/src/app/api/v1/sales-persons/__tests__/route.test.ts
@@ -695,7 +695,7 @@ describe('POST /api/v1/sales-persons', () => {
       expect(data.error.code).toBe('UNAUTHORIZED');
     });
 
-    it('IT-030-02: 一般営業が登録しようとすると403を返す', async () => {
+    it('[IT-030-02] 一般営業が登録しようとすると403を返す', async () => {
       const payload: JwtPayload = {
         userId: mockMember.id,
         email: mockMember.email,
@@ -735,7 +735,7 @@ describe('POST /api/v1/sales-persons', () => {
   });
 
   describe('正常系', () => {
-    it('IT-030-01: 管理者が正常に登録できる', async () => {
+    it('[IT-030-01] 管理者が正常に登録できる', async () => {
       const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
       const createMock = vi.mocked(prisma.salesPerson.create);
 
@@ -882,7 +882,7 @@ describe('POST /api/v1/sales-persons', () => {
   });
 
   describe('重複エラー', () => {
-    it('IT-030-03: 社員番号が重複している場合は409を返す', async () => {
+    it('[IT-030-03] 社員番号が重複している場合は409を返す', async () => {
       const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
 
       // 社員番号が既に存在
@@ -907,7 +907,7 @@ describe('POST /api/v1/sales-persons', () => {
       expect(data.error.message).toBe('この社員番号は既に使用されています');
     });
 
-    it('IT-030-04: メールアドレスが重複している場合は409を返す', async () => {
+    it('[IT-030-04] メールアドレスが重複している場合は409を返す', async () => {
       const findUniqueMock = vi.mocked(prisma.salesPerson.findUnique);
 
       // 社員番号は重複なし、メールが既に存在
@@ -936,7 +936,7 @@ describe('POST /api/v1/sales-persons', () => {
   });
 
   describe('バリデーションエラー', () => {
-    it('IT-030-05: パスワードが8文字未満の場合は422を返す', async () => {
+    it('[IT-030-05] パスワードが8文字未満の場合は422を返す', async () => {
       const payload: JwtPayload = {
         userId: mockAdmin.id,
         email: mockAdmin.email,


### PR DESCRIPTION
## Summary
- 営業マスタAPIと顧客マスタAPIの既存テストにテストIDプレフィックスを追加
- テスト仕様書（docs/test-specification.md）との対応を明確化

## 実装したテストケース

### IT-030: POST /api/v1/sales-persons
| テストID | テスト内容 | 期待結果 |
|----------|------------|----------|
| IT-030-01 | 管理者が正常登録 | 201 |
| IT-030-02 | 一般営業が登録 | 403 |
| IT-030-03 | 社員番号重複 | 409 |
| IT-030-04 | メールアドレス重複 | 409 |
| IT-030-05 | パスワード短すぎ | 422 |

### IT-040: POST /api/v1/customers
| テストID | テスト内容 | 期待結果 |
|----------|------------|----------|
| IT-040-01 | 管理者が正常登録 | 201 |
| IT-040-02 | 一般営業が登録 | 403 |
| IT-040-03 | 顧客コード重複 | 409 |

## Test plan
- [x] 営業マスタAPIテスト（35件）がパスする
- [x] 顧客マスタAPIテスト（59件）がパスする
- [x] 全テスト（94件）がパスする

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)