### PR TITLE
test: E2Eテスト - ログインシナリオ (E2E-001)

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,212 @@
+import { expect, test } from '@playwright/test';
+
+import { login, logout } from './helpers/auth';
+
+/**
+ * 認証機能 E2Eテスト (E2E-001)
+ *
+ * テスト仕様書のE2E-001に対応するログインシナリオをテストする。
+ * - E2E-001-01: 正常ログイン
+ * - E2E-001-02: ログイン失敗
+ * - E2E-001-03: ログアウト
+ *
+ * テストデータ:
+ * - 一般営業: yamada@example.com / member123
+ * - 上長: manager@example.com / manager123
+ * - 管理者: admin@example.com / admin123
+ */
+test.describe('E2E-001: ログインシナリオ', () => {
+  test.describe('E2E-001-01: 正常ログイン', () => {
+    test('メールアドレスとパスワードを入力してログインするとダッシュボードに遷移する', async ({
+      page,
+    }) => {
+      // 1. ログイン画面を表示
+      await page.goto('/login');
+
+      // ローディングが終わるまで待機
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      // ログイン画面のタイトルが表示されていることを確認（CardTitleはdiv要素なのでテキストで検索）
+      await expect(
+        page.locator('[data-slot="card-title"]').getByText('営業日報システム')
+      ).toBeVisible();
+
+      // 2. メールアドレスを入力
+      const emailInput = page.locator('input[name="email"]');
+      await emailInput.fill('yamada@example.com');
+
+      // 3. パスワードを入力
+      const passwordInput = page.locator('input[name="password"]');
+      await passwordInput.fill('member123');
+
+      // 4. ログインボタンをクリック
+      const loginButton = page.getByRole('button', { name: 'ログイン' });
+      await loginButton.click();
+
+      // 5. ダッシュボードに遷移することを確認
+      await page.waitForURL('/');
+
+      // ダッシュボードのコンテンツが表示されていることを確認
+      await expect(page.getByRole('heading', { name: '日報一覧' })).toBeVisible();
+    });
+
+    test('上長アカウントでログインできる', async ({ page }) => {
+      await page.goto('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      await page.fill('input[name="email"]', 'manager@example.com');
+      await page.fill('input[name="password"]', 'manager123');
+      await page.click('button[type="submit"]');
+
+      await page.waitForURL('/', { timeout: 30000 });
+      await expect(page.getByRole('heading', { name: '日報一覧' })).toBeVisible();
+    });
+
+    test('管理者アカウントでログインできる', async ({ page }) => {
+      await page.goto('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      await page.fill('input[name="email"]', 'admin@example.com');
+      await page.fill('input[name="password"]', 'admin123');
+      await page.click('button[type="submit"]');
+
+      await page.waitForURL('/', { timeout: 30000 });
+      await expect(page.getByRole('heading', { name: '日報一覧' })).toBeVisible();
+    });
+  });
+
+  test.describe('E2E-001-02: ログイン失敗', () => {
+    test('誤ったパスワードでログインするとエラーメッセージが表示される', async ({ page }) => {
+      // 1. ログイン画面を表示
+      await page.goto('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      // 2. 正しいメールアドレスと誤ったパスワードを入力
+      await page.fill('input[name="email"]', 'yamada@example.com');
+      await page.fill('input[name="password"]', 'wrongpassword');
+
+      // 3. ログインボタンをクリック
+      await page.click('button[type="submit"]');
+
+      // 4. エラーメッセージが表示されることを確認
+      await expect(
+        page.getByText('メールアドレスまたはパスワードが正しくありません')
+      ).toBeVisible();
+
+      // ログイン画面に留まっていることを確認
+      await expect(page).toHaveURL('/login');
+    });
+
+    test('存在しないメールアドレスでログインするとエラーメッセージが表示される', async ({
+      page,
+    }) => {
+      await page.goto('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      await page.fill('input[name="email"]', 'nonexistent@example.com');
+      await page.fill('input[name="password"]', 'anypassword');
+      await page.click('button[type="submit"]');
+
+      await expect(
+        page.getByText('メールアドレスまたはパスワードが正しくありません')
+      ).toBeVisible();
+      await expect(page).toHaveURL('/login');
+    });
+
+    test('メールアドレスを空にして送信するとバリデーションエラーが表示される', async ({ page }) => {
+      await page.goto('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      // パスワードのみ入力
+      await page.fill('input[name="password"]', 'member123');
+      await page.click('button[type="submit"]');
+
+      // バリデーションエラーメッセージが表示される
+      await expect(page.getByText('メールアドレスを入力してください')).toBeVisible();
+    });
+
+    test('パスワードを空にして送信するとバリデーションエラーが表示される', async ({ page }) => {
+      await page.goto('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      // メールアドレスのみ入力
+      await page.fill('input[name="email"]', 'yamada@example.com');
+      await page.click('button[type="submit"]');
+
+      // バリデーションエラーメッセージが表示される
+      await expect(page.getByText('パスワードを入力してください')).toBeVisible();
+    });
+
+    test('無効なメール形式を入力するとバリデーションエラーが表示される', async ({ page }) => {
+      await page.goto('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+
+      await page.fill('input[name="email"]', 'invalid-email');
+      await page.fill('input[name="password"]', 'member123');
+      await page.click('button[type="submit"]');
+
+      // バリデーションエラーメッセージが表示される
+      await expect(page.getByText('有効なメールアドレスを入力してください')).toBeVisible();
+    });
+  });
+
+  test.describe('E2E-001-03: ログアウト', () => {
+    test('ログイン状態でログアウトするとログイン画面に遷移する', async ({ page }) => {
+      // 1. ログインしてダッシュボードを表示
+      await login(page, 'yamada@example.com', 'member123');
+
+      // ダッシュボードが表示されていることを確認
+      await expect(page.getByRole('heading', { name: '日報一覧' })).toBeVisible();
+
+      // 2. ログアウトを実行
+      await logout(page);
+
+      // 3. ログイン画面に遷移することを確認
+      await expect(page).toHaveURL('/login');
+
+      // ログイン画面のタイトルが表示されていることを確認
+      await expect(
+        page.locator('[data-slot="card-title"]').getByText('営業日報システム')
+      ).toBeVisible();
+    });
+
+    test('ログアウト後にダッシュボードにアクセスするとログイン画面にリダイレクトされる', async ({
+      page,
+    }) => {
+      // ログインしてダッシュボード表示
+      await login(page, 'yamada@example.com', 'member123');
+      await expect(page.getByRole('heading', { name: '日報一覧' })).toBeVisible();
+
+      // ログアウト
+      await logout(page);
+      await expect(page).toHaveURL('/login');
+
+      // ダッシュボードに直接アクセスを試みる
+      await page.goto('/');
+
+      // ログイン画面にリダイレクトされることを確認
+      await page.waitForURL('/login');
+      await page.waitForSelector('input[name="email"]', { timeout: 30000 });
+      await expect(
+        page.locator('[data-slot="card-title"]').getByText('営業日報システム')
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('認証済みユーザーの動作', () => {
+    test('ログイン済みでログイン画面にアクセスするとダッシュボードにリダイレクトされる', async ({
+      page,
+    }) => {
+      // ログイン
+      await login(page, 'yamada@example.com', 'member123');
+      await expect(page.getByRole('heading', { name: '日報一覧' })).toBeVisible();
+
+      // ログイン画面に直接アクセスを試みる
+      await page.goto('/login');
+
+      // ダッシュボードにリダイレクトされることを確認
+      await page.waitForURL('/');
+      await expect(page.getByRole('heading', { name: '日報一覧' })).toBeVisible();
+    });
+  });
+});

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -9,11 +9,15 @@ export async function login(
   password: string = 'member123'
 ) {
   await page.goto('/login');
+  // ローディングが終わるまで待機
+  await page.waitForSelector('input[name="email"]', { timeout: 30000 });
   await page.fill('input[name="email"]', email);
   await page.fill('input[name="password"]', password);
   await page.click('button[type="submit"]');
   // ダッシュボードにリダイレクトされるまで待機
-  await page.waitForURL('/');
+  await page.waitForURL('/', { timeout: 30000 });
+  // ダッシュボードのコンテンツが表示されるまで待機
+  await page.waitForSelector('[data-testid="user-menu"]', { timeout: 30000 });
 }
 
 /**
@@ -22,5 +26,7 @@ export async function login(
 export async function logout(page: Page) {
   await page.click('[data-testid="user-menu"]');
   await page.click('[data-testid="logout-button"]');
-  await page.waitForURL('/login');
+  await page.waitForURL('/login', { timeout: 30000 });
+  // ログイン画面のフォームが表示されるまで待機
+  await page.waitForSelector('input[name="email"]', { timeout: 30000 });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ErrorMessage } from '@/components/common/ErrorMessage';
 import { LoadingPage } from '@/components/common/Loading';
 import { ReportTable, SearchForm, type SearchFormValues } from '@/components/dashboard';
+import { Header } from '@/components/layout/Header';
 import { PageContainer } from '@/components/layout/PageContainer';
 import { Button } from '@/components/ui/button';
 import { useRequireAuth } from '@/hooks/useAuth';
@@ -112,44 +113,49 @@ export default function Dashboard() {
   }
 
   return (
-    <PageContainer
-      title="日報一覧"
-      actions={
-        <Button asChild>
-          <Link href="/reports/new">
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            新規作成
-          </Link>
-        </Button>
-      }
-    >
-      {/* 検索フォーム */}
-      <div className="mb-6">
-        <SearchForm
-          values={searchValues}
-          onChange={setSearchValues}
-          onSearch={handleSearch}
-          salesPersons={salesPersons}
-          currentUserId={auth.user?.id}
-          currentUserRole={auth.user?.role}
+    <>
+      {/* ヘッダー */}
+      <Header userName={auth.user?.name} userRole={auth.user?.role} onLogout={auth.logout} />
+
+      <PageContainer
+        title="日報一覧"
+        actions={
+          <Button asChild>
+            <Link href="/reports/new">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              新規作成
+            </Link>
+          </Button>
+        }
+      >
+        {/* 検索フォーム */}
+        <div className="mb-6">
+          <SearchForm
+            values={searchValues}
+            onChange={setSearchValues}
+            onSearch={handleSearch}
+            salesPersons={salesPersons}
+            currentUserId={auth.user?.id}
+            currentUserRole={auth.user?.role}
+            isLoading={isReportsLoading}
+          />
+        </div>
+
+        {/* エラーメッセージ */}
+        {error && (
+          <div className="mb-6">
+            <ErrorMessage message={error} />
+          </div>
+        )}
+
+        {/* 日報一覧テーブル */}
+        <ReportTable
+          reports={reports}
+          pagination={pagination}
+          onPageChange={handlePageChange}
           isLoading={isReportsLoading}
         />
-      </div>
-
-      {/* エラーメッセージ */}
-      {error && (
-        <div className="mb-6">
-          <ErrorMessage message={error} />
-        </div>
-      )}
-
-      {/* 日報一覧テーブル */}
-      <ReportTable
-        reports={reports}
-        pagination={pagination}
-        onPageChange={handlePageChange}
-        isLoading={isReportsLoading}
-      />
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -67,7 +67,7 @@ export function Header({ userName, userRole, onLogout }: HeaderProps) {
             <div className="hidden md:flex items-center gap-4">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" className="gap-2">
+                  <Button variant="ghost" className="gap-2" data-testid="user-menu">
                     <User className="h-4 w-4" />
                     {userName}
                     <ChevronDown className="h-4 w-4" />
@@ -84,7 +84,7 @@ export function Header({ userName, userRole, onLogout }: HeaderProps) {
                     </span>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={onLogout}>
+                  <DropdownMenuItem onClick={onLogout} data-testid="logout-button">
                     <LogOut className="mr-2 h-4 w-4" />
                     ログアウト
                   </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Playwrightを使用したログイン機能のE2Eテストを実装
- テスト仕様書（docs/test-specification.md）のE2E-001に対応

## 実装したテストシナリオ

### E2E-001-01: 正常ログイン
| テスト名 | 内容 |
|----------|------|
| メールアドレスとパスワードを入力してログインするとダッシュボードに遷移する | 一般営業アカウントでログイン |
| 上長アカウントでログインできる | manager@example.com でログイン |
| 管理者アカウントでログインできる | admin@example.com でログイン |

### E2E-001-02: ログイン失敗
| テスト名 | 内容 |
|----------|------|
| 誤ったパスワードでログインするとエラーメッセージが表示される | 認証エラー |
| 存在しないメールアドレスでログインするとエラーメッセージが表示される | 認証エラー |
| メールアドレスを空にして送信するとバリデーションエラーが表示される | バリデーション |
| パスワードを空にして送信するとバリデーションエラーが表示される | バリデーション |
| 無効なメール形式を入力するとバリデーションエラーが表示される | バリデーション |

### E2E-001-03: ログアウト
| テスト名 | 内容 |
|----------|------|
| ログイン状態でログアウトするとログイン画面に遷移する | ログアウト機能 |
| ログアウト後にダッシュボードにアクセスするとログイン画面にリダイレクトされる | 認証ガード |

### 追加テスト
| テスト名 | 内容 |
|----------|------|
| ログイン済みでログイン画面にアクセスするとダッシュボードにリダイレクトされる | 認証済みガード |

## 変更ファイル
- `e2e/auth.spec.ts` - E2Eテストファイル（新規作成）
- `e2e/helpers/auth.ts` - ヘルパー関数の改善
- `src/app/page.tsx` - ダッシュボードにHeaderコンポーネント追加
- `src/components/layout/Header.tsx` - テスト用data-testid追加

## Test plan
- [x] E2E-001-01（正常ログイン）3テストがパス
- [x] E2E-001-02（ログイン失敗）5テストがパス
- [x] E2E-001-03（ログアウト）2テストがパス
- [x] 追加テスト1件がパス
- [x] 全11テストがパス

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)