### PR TITLE
fix: Issue #109 テストファイルのTypeScript型エラーを修正

### DIFF
--- a/src/app/api/v1/reports/__tests__/route.test.ts
+++ b/src/app/api/v1/reports/__tests__/route.test.ts
@@ -417,9 +417,11 @@ describe('GET /api/v1/reports', () => {
       expect(data.success).toBe(true);
 
       // countの呼び出し引数を確認
-      const countCall = countMock.mock.calls[0][0];
-      expect(countCall.where.reportDate).toBeDefined();
-      expect(countCall.where.reportDate.gte).toBeInstanceOf(Date);
+      const countCall = countMock.mock.calls[0]?.[0] as {
+        where?: { reportDate?: { gte?: Date; lte?: Date } };
+      };
+      expect(countCall?.where?.reportDate).toBeDefined();
+      expect(countCall?.where?.reportDate?.gte).toBeInstanceOf(Date);
     });
 
     it('終了日のみ指定した場合、その日以前の日報を取得する', async () => {
@@ -447,9 +449,11 @@ describe('GET /api/v1/reports', () => {
       expect(data.success).toBe(true);
 
       // countの呼び出し引数を確認
-      const countCall = countMock.mock.calls[0][0];
-      expect(countCall.where.reportDate).toBeDefined();
-      expect(countCall.where.reportDate.lte).toBeInstanceOf(Date);
+      const countCall = countMock.mock.calls[0]?.[0] as {
+        where?: { reportDate?: { gte?: Date; lte?: Date } };
+      };
+      expect(countCall?.where?.reportDate).toBeDefined();
+      expect(countCall?.where?.reportDate?.lte).toBeInstanceOf(Date);
     });
 
     it('開始日と終了日を指定した場合、その範囲の日報を取得する', async () => {
@@ -483,9 +487,11 @@ describe('GET /api/v1/reports', () => {
       expect(data.success).toBe(true);
 
       // countの呼び出し引数を確認
-      const countCall = countMock.mock.calls[0][0];
-      expect(countCall.where.reportDate.gte).toBeInstanceOf(Date);
-      expect(countCall.where.reportDate.lte).toBeInstanceOf(Date);
+      const countCall = countMock.mock.calls[0]?.[0] as {
+        where?: { reportDate?: { gte?: Date; lte?: Date } };
+      };
+      expect(countCall?.where?.reportDate?.gte).toBeInstanceOf(Date);
+      expect(countCall?.where?.reportDate?.lte).toBeInstanceOf(Date);
     });
 
     it('開始日が終了日より後の場合はバリデーションエラーを返す', async () => {
@@ -536,8 +542,8 @@ describe('GET /api/v1/reports', () => {
       expect(data.success).toBe(true);
 
       // countの呼び出し引数を確認
-      const countCall = countMock.mock.calls[0][0];
-      expect(countCall.where.status).toBe('submitted');
+      const countCall = countMock.mock.calls[0]?.[0] as { where?: { status?: string } };
+      expect(countCall?.where?.status).toBe('submitted');
     });
 
     it('draftステータスの日報のみ取得できる', async () => {
@@ -564,8 +570,8 @@ describe('GET /api/v1/reports', () => {
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
 
-      const countCall = countMock.mock.calls[0][0];
-      expect(countCall.where.status).toBe('draft');
+      const countCall = countMock.mock.calls[0]?.[0] as { where?: { status?: string } };
+      expect(countCall?.where?.status).toBe('draft');
     });
 
     it('reviewedステータスの日報のみ取得できる', async () => {
@@ -592,8 +598,8 @@ describe('GET /api/v1/reports', () => {
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
 
-      const countCall = countMock.mock.calls[0][0];
-      expect(countCall.where.status).toBe('reviewed');
+      const countCall = countMock.mock.calls[0]?.[0] as { where?: { status?: string } };
+      expect(countCall?.where?.status).toBe('reviewed');
     });
 
     it('無効なステータスの場合はバリデーションエラーを返す', async () => {
@@ -644,9 +650,9 @@ describe('GET /api/v1/reports', () => {
       });
 
       // findManyの呼び出し引数を確認
-      const findManyCall = findManyMock.mock.calls[0][0];
-      expect(findManyCall.skip).toBe(0);
-      expect(findManyCall.take).toBe(20);
+      const findManyCall = findManyMock.mock.calls[0]?.[0] as { skip?: number; take?: number };
+      expect(findManyCall?.skip).toBe(0);
+      expect(findManyCall?.take).toBe(20);
     });
 
     it('page=2, per_page=10で2ページ目を取得する', async () => {
@@ -678,9 +684,9 @@ describe('GET /api/v1/reports', () => {
       });
 
       // findManyの呼び出し引数を確認
-      const findManyCall = findManyMock.mock.calls[0][0];
-      expect(findManyCall.skip).toBe(10); // (2-1) * 10 = 10
-      expect(findManyCall.take).toBe(10);
+      const findManyCall = findManyMock.mock.calls[0]?.[0] as { skip?: number; take?: number };
+      expect(findManyCall?.skip).toBe(10); // (2-1) * 10 = 10
+      expect(findManyCall?.take).toBe(10);
     });
 
     it('per_page=100を超える値はバリデーションエラーを返す', async () => {
@@ -893,15 +899,17 @@ describe('GET /api/v1/reports', () => {
       expect(data.success).toBe(true);
 
       // countの呼び出し引数を確認
-      const countCall = countMock.mock.calls[0][0];
-      expect(countCall.where.salesPersonId).toBeDefined();
-      expect(countCall.where.reportDate).toBeDefined();
-      expect(countCall.where.status).toBe('submitted');
+      const countCall = countMock.mock.calls[0]?.[0] as {
+        where?: { salesPersonId?: number; reportDate?: unknown; status?: string };
+      };
+      expect(countCall?.where?.salesPersonId).toBeDefined();
+      expect(countCall?.where?.reportDate).toBeDefined();
+      expect(countCall?.where?.status).toBe('submitted');
 
       // findManyの呼び出し引数を確認
-      const findManyCall = findManyMock.mock.calls[0][0];
-      expect(findManyCall.skip).toBe(0);
-      expect(findManyCall.take).toBe(10);
+      const findManyCall = findManyMock.mock.calls[0]?.[0] as { skip?: number; take?: number };
+      expect(findManyCall?.skip).toBe(0);
+      expect(findManyCall?.take).toBe(10);
     });
   });
 
@@ -925,8 +933,10 @@ describe('GET /api/v1/reports', () => {
       await GET(request);
 
       // findManyの呼び出し引数を確認
-      const findManyCall = findManyMock.mock.calls[0][0];
-      expect(findManyCall.orderBy).toEqual([{ reportDate: 'desc' }, { id: 'desc' }]);
+      const findManyCall = findManyMock.mock.calls[0]?.[0] as {
+        orderBy?: Array<{ reportDate?: string; id?: string }>;
+      };
+      expect(findManyCall?.orderBy).toEqual([{ reportDate: 'desc' }, { id: 'desc' }]);
     });
   });
 });

--- a/src/app/api/v1/sales-persons/__tests__/route.test.ts
+++ b/src/app/api/v1/sales-persons/__tests__/route.test.ts
@@ -182,8 +182,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token);
@@ -211,8 +209,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token);
@@ -249,8 +245,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockManager.id,
         email: mockManager.email,
         role: mockManager.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token);
@@ -277,8 +271,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { is_active: 'true' });
@@ -308,8 +300,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { is_active: 'false' });
@@ -341,8 +331,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { role: 'member' });
@@ -372,8 +360,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { role: 'manager' });
@@ -403,8 +389,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { role: 'admin' });
@@ -427,8 +411,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { role: 'invalid_role' });
@@ -455,8 +437,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { is_active: 'true', role: 'member' });
@@ -487,8 +467,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token);
@@ -522,8 +500,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { page: '2', per_page: '10' });
@@ -551,8 +527,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { per_page: '101' });
@@ -571,8 +545,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { page: '0' });
@@ -590,8 +562,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token, { per_page: '0' });
@@ -614,8 +584,6 @@ describe('GET /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: mockMember.role,
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createRequest(token);
@@ -700,8 +668,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockMember.id,
         email: mockMember.email,
         role: 'member',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, validRequestBody);
@@ -719,8 +685,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockManager.id,
         email: mockManager.email,
         role: 'manager',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, validRequestBody);
@@ -764,8 +728,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, validRequestBody);
@@ -815,8 +777,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -859,8 +819,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       // role と is_active を省略
@@ -892,8 +850,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, validRequestBody);
@@ -919,8 +875,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, validRequestBody);
@@ -941,8 +895,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -964,8 +916,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -986,8 +936,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -1008,8 +956,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -1030,8 +976,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -1052,8 +996,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -1082,8 +1024,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, {
@@ -1117,8 +1057,6 @@ describe('POST /api/v1/sales-persons', () => {
         userId: mockAdmin.id,
         email: mockAdmin.email,
         role: 'admin',
-        iat: Math.floor(Date.now() / 1000),
-        exp: Math.floor(Date.now() / 1000) + 3600,
       };
       const token = await generateToken(payload);
       const request = createPostRequest(token, validRequestBody);

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -40,7 +40,7 @@ const mockUser: AuthUser = {
  * AuthContextの値を表示するテスト用コンポーネント
  */
 function TestConsumer() {
-  const auth = useContext(AuthContext);
+  const auth = useContext(AuthContext)!;
   const [loginError, setLoginError] = useState<string | null>(null);
 
   const handleLogin = async () => {


### PR DESCRIPTION
## Summary
- テストファイルで発生していた68個のTypeScript型エラーを修正
- 型アサーションと非nullアサーションを追加してコンパイルエラーを解消
- 不要なJWTプロパティ（iat/exp）をテストから削除

## Changes
- `src/app/api/v1/reports/__tests__/route.test.ts`: countCall/findManyCallに型アサーションを追加
- `src/app/api/v1/sales-persons/__tests__/route.test.ts`: 不要なiat/expプロパティを削除（generateTokenが自動追加するため）
- `src/contexts/__tests__/AuthContext.test.tsx`: useContextに非nullアサーション（!）を追加

## Test plan
- [x] `npx tsc --noEmit` で型チェック成功
- [x] `npm run lint` でLintチェック成功
- [x] `npm run test:run` で全795テスト成功

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)